### PR TITLE
feat: add upgrade_package target to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,8 +29,8 @@ docs: ## generate Sphinx HTML documentation, including API docs
 	tox -e docs
 	$(BROWSER)docs/_build/html/index.html
 
-# Define PIP_COMPILE_OPTS=-v to get more information during make upgrade.
-CMD_PIP_COMPILE ?= pip-compile --rebuild --upgrade $(PIP_COMPILE_OPTS)
+# Define CMD_PIP_COMPILE_OPTS=-v to get more information during make upgrade.
+CMD_PIP_COMPILE ?= pip-compile --rebuild --upgrade $(CMD_PIP_COMPILE_OPTS)
 
 upgrade: export CUSTOM_COMPILE_COMMAND=make upgrade
 upgrade: ## update the requirements/*.txt files with the latest packages satisfying requirements/*.in

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ docs: ## generate Sphinx HTML documentation, including API docs
 	$(BROWSER)docs/_build/html/index.html
 
 # Define PIP_COMPILE_OPTS=-v to get more information during make upgrade.
-PIP_COMPILE = pip-compile --rebuild --upgrade-package $(package)
+PIP_COMPILE = pip-compile --rebuild --upgrade $(PIP_COMPILE_OPTS)
 
 upgrade: export CUSTOM_COMPILE_COMMAND=make upgrade
 upgrade: ## update the requirements/*.txt files with the latest packages satisfying requirements/*.in

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: clean compile_translations coverage diff_cover docs dummy_translations \
         extract_translations fake_translations help pii_check pull_translations push_translations \
-        quality requirements selfcheck test test-all upgrade validate
+        quality requirements selfcheck test test-all upgrade validate upgrade_package
 
 .DEFAULT_GOAL := help
 
@@ -30,7 +30,7 @@ docs: ## generate Sphinx HTML documentation, including API docs
 	$(BROWSER)docs/_build/html/index.html
 
 # Define PIP_COMPILE_OPTS=-v to get more information during make upgrade.
-PIP_COMPILE = pip-compile --rebuild --upgrade $(PIP_COMPILE_OPTS)
+PIP_COMPILE = pip-compile --rebuild --upgrade-package $(package)
 
 upgrade: export CUSTOM_COMPILE_COMMAND=make upgrade
 upgrade: ## update the requirements/*.txt files with the latest packages satisfying requirements/*.in
@@ -49,6 +49,12 @@ upgrade: ## update the requirements/*.txt files with the latest packages satisfy
 	# Let tox control the Django version for tests
 	sed '/^[dD]jango==/d' requirements/test.txt > requirements/test.tmp
 	mv requirements/test.tmp requirements/test.txt
+
+
+upgrade_package: export CUSTOM_COMPILE_COMMAND=make upgrade
+upgrade_package:
+	PIP_COMPILE="pip-compile --rebuild --upgrade-package $(package)"
+	make upgrade
 
 quality: ## check coding style with pycodestyle and pylint
 	tox -e quality

--- a/Makefile
+++ b/Makefile
@@ -30,23 +30,22 @@ docs: ## generate Sphinx HTML documentation, including API docs
 	$(BROWSER)docs/_build/html/index.html
 
 # Define PIP_COMPILE_OPTS=-v to get more information during make upgrade.
-PIP_COMPILE ?= pip-compile --rebuild --upgrade $(PIP_COMPILE_OPTS)
-PIP_COMPILE_LIBRARIES ?= $(PIP_COMPILE)
+CMD_PIP_COMPILE ?= pip-compile --rebuild --upgrade $(PIP_COMPILE_OPTS)
 
 upgrade: export CUSTOM_COMPILE_COMMAND=make upgrade
 upgrade: ## update the requirements/*.txt files with the latest packages satisfying requirements/*.in
 	pip install -qr requirements/pip-tools.txt
 	# Make sure to compile files after any other files they include!
-	$(PIP_COMPILE) --allow-unsafe --rebuild -o requirements/pip.txt requirements/pip.in
-	$(PIP_COMPILE) -o requirements/pip-tools.txt requirements/pip-tools.in
+	$(CMD_PIP_COMPILE) --allow-unsafe --rebuild -o requirements/pip.txt requirements/pip.in
+	$(CMD_PIP_COMPILE) -o requirements/pip-tools.txt requirements/pip-tools.in
 	pip install -qr requirements/pip.txt
 	pip install -qr requirements/pip-tools.txt
-	$(PIP_COMPILE_LIBRARIES) -o requirements/base.txt requirements/base.in
-	$(PIP_COMPILE_LIBRARIES) -o requirements/test.txt requirements/test.in
-	$(PIP_COMPILE_LIBRARIES) -o requirements/doc.txt requirements/doc.in
-	$(PIP_COMPILE_LIBRARIES) -o requirements/quality.txt requirements/quality.in
-	$(PIP_COMPILE_LIBRARIES) -o requirements/ci.txt requirements/ci.in
-	$(PIP_COMPILE_LIBRARIES) -o requirements/dev.txt requirements/dev.in
+	$(CMD_PIP_COMPILE) -o requirements/base.txt requirements/base.in
+	$(CMD_PIP_COMPILE) -o requirements/test.txt requirements/test.in
+	$(CMD_PIP_COMPILE) -o requirements/doc.txt requirements/doc.in
+	$(CMD_PIP_COMPILE) -o requirements/quality.txt requirements/quality.in
+	$(CMD_PIP_COMPILE) -o requirements/ci.txt requirements/ci.in
+	$(CMD_PIP_COMPILE) -o requirements/dev.txt requirements/dev.in
 	# Let tox control the Django version for tests
 	sed '/^[dD]jango==/d' requirements/test.txt > requirements/test.tmp
 	mv requirements/test.tmp requirements/test.txt
@@ -54,7 +53,7 @@ upgrade: ## update the requirements/*.txt files with the latest packages satisfy
 
 upgrade_package: ## update the requirements/*.txt file with the latest version of $package
 	@test -n "$(package)" || { echo "\nUsage: make upgrade_package package=...\n"; exit 1; }
-	PIP_COMPILE_LIBRARIES="pip-compile --rebuild --upgrade-package $(package)" make upgrade
+	CMD_PIP_COMPILE="pip-compile --rebuild --upgrade-package $(package)" make upgrade
 
 quality: ## check coding style with pycodestyle and pylint
 	tox -e quality

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,8 @@ docs: ## generate Sphinx HTML documentation, including API docs
 	$(BROWSER)docs/_build/html/index.html
 
 # Define PIP_COMPILE_OPTS=-v to get more information during make upgrade.
-PIP_COMPILE = pip-compile --rebuild --upgrade $(PIP_COMPILE_OPTS)
+PIP_COMPILE ?= pip-compile --rebuild --upgrade $(PIP_COMPILE_OPTS)
+PIP_COMPILE_LIBRARIES ?= $(PIP_COMPILE)
 
 upgrade: export CUSTOM_COMPILE_COMMAND=make upgrade
 upgrade: ## update the requirements/*.txt files with the latest packages satisfying requirements/*.in
@@ -40,21 +41,21 @@ upgrade: ## update the requirements/*.txt files with the latest packages satisfy
 	$(PIP_COMPILE) -o requirements/pip-tools.txt requirements/pip-tools.in
 	pip install -qr requirements/pip.txt
 	pip install -qr requirements/pip-tools.txt
-	$(PIP_COMPILE) -o requirements/base.txt requirements/base.in
-	$(PIP_COMPILE) -o requirements/test.txt requirements/test.in
-	$(PIP_COMPILE) -o requirements/doc.txt requirements/doc.in
-	$(PIP_COMPILE) -o requirements/quality.txt requirements/quality.in
-	$(PIP_COMPILE) -o requirements/ci.txt requirements/ci.in
-	$(PIP_COMPILE) -o requirements/dev.txt requirements/dev.in
+	$(PIP_COMPILE_LIBRARIES) -o requirements/base.txt requirements/base.in
+	$(PIP_COMPILE_LIBRARIES) -o requirements/test.txt requirements/test.in
+	$(PIP_COMPILE_LIBRARIES) -o requirements/doc.txt requirements/doc.in
+	$(PIP_COMPILE_LIBRARIES) -o requirements/quality.txt requirements/quality.in
+	$(PIP_COMPILE_LIBRARIES) -o requirements/ci.txt requirements/ci.in
+	$(PIP_COMPILE_LIBRARIES) -o requirements/dev.txt requirements/dev.in
 	# Let tox control the Django version for tests
 	sed '/^[dD]jango==/d' requirements/test.txt > requirements/test.tmp
 	mv requirements/test.tmp requirements/test.txt
 
 
 upgrade_package: export CUSTOM_COMPILE_COMMAND=make upgrade
-upgrade_package: ## update the requirements/*.txt file with the latest version of $package 
-	PIP_COMPILE="pip-compile --rebuild --upgrade-package $(package)"
-	make upgrade
+upgrade_package: ## update the requirements/*.txt file with the latest version of $package
+	@test -n "$(package)" || { echo "\nUsage: make upgrade_package package=...\n"; exit 1; }
+	PIP_COMPILE_LIBRARIES="pip-compile --rebuild --upgrade-package $(package)" make upgrade
 
 quality: ## check coding style with pycodestyle and pylint
 	tox -e quality

--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,6 @@ upgrade: ## update the requirements/*.txt files with the latest packages satisfy
 	mv requirements/test.tmp requirements/test.txt
 
 
-upgrade_package: export CUSTOM_COMPILE_COMMAND=make upgrade
 upgrade_package: ## update the requirements/*.txt file with the latest version of $package
 	@test -n "$(package)" || { echo "\nUsage: make upgrade_package package=...\n"; exit 1; }
 	PIP_COMPILE_LIBRARIES="pip-compile --rebuild --upgrade-package $(package)" make upgrade

--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ upgrade: ## update the requirements/*.txt files with the latest packages satisfy
 
 
 upgrade_package: export CUSTOM_COMPILE_COMMAND=make upgrade
-upgrade_package:
+upgrade_package: ## update the requirements/*.txt file with the latest version of $package 
 	PIP_COMPILE="pip-compile --rebuild --upgrade-package $(package)"
 	make upgrade
 

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -8,7 +8,7 @@ click==8.0.4
     # via pip-tools
 pep517==0.12.0
     # via pip-tools
-pip-tools==6.5.1
+pip-tools==6.6.2
     # via -r requirements/pip-tools.in
 tomli==2.0.1
     # via pep517


### PR DESCRIPTION
Add upgrade_package target to Makefile for upgrading a specific package to the latest version.
Usage: `make upgrade_package package=my-package`