### PR TITLE
docs: add consequence to consumer ADR

### DIFF
--- a/edx_arch_experiments/kafka_consumer/docs/decisions/0002_kafka_consumer_command.rst
+++ b/edx_arch_experiments/kafka_consumer/docs/decisions/0002_kafka_consumer_command.rst
@@ -20,7 +20,7 @@ Decision
 --------
 edX.org will use Kubernetes to manage containers whose sole purpose is to run a management command, which in turn will run a polling loop against the specified topic. This will enable standard horizontal scaling of Kafka consumer groups.
 
-The loop will both listen for new events and then kick off the processing code for each event.
+The loop will listen for new events and then kick off the processing code for each event.
 
 The new consumer containers will share access to the database and the same codebase as the backend service it supports. These would all be considered part of the same bounded context (from Domain-Driven Design).
 

--- a/edx_arch_experiments/kafka_consumer/docs/decisions/0002_kafka_consumer_command.rst
+++ b/edx_arch_experiments/kafka_consumer/docs/decisions/0002_kafka_consumer_command.rst
@@ -20,7 +20,14 @@ Decision
 --------
 edX.org will use Kubernetes to manage containers whose sole purpose is to run a management command, which in turn will run a polling loop against the specified topic. This will enable standard horizontal scaling of Kafka consumer groups.
 
-The loop will both listen for new events and run any necessary processing code for each event.
+The loop will both listen for new events and then kick off the processing code for each event.
+
+The new consumer containers will share access to the database and the same codebase as the backend service it supports. These would all be considered part of the same bounded context (from Domain-Driven Design).
+
+Consequences
+------------
+
+* If the new consumer is supporting a backend service that is not yet deployed using Kubernetes, care must be taken to ensure consumers are deployed with the rest of the app. For example, if the backend service is deployed to AWS instance. Considerations need to be made if one part of this deployment breaks, but not another part.
 
 Rejected Alternatives
 ---------------------

--- a/edx_arch_experiments/kafka_consumer/docs/decisions/0002_kafka_consumer_command.rst
+++ b/edx_arch_experiments/kafka_consumer/docs/decisions/0002_kafka_consumer_command.rst
@@ -27,7 +27,7 @@ The new consumer containers will share access to the database and the same codeb
 Consequences
 ------------
 
-* If the new consumer is supporting a backend service that is not yet deployed using Kubernetes, care must be taken to ensure consumers are deployed with the rest of the app. For example, if the backend service is deployed to AWS instance. Considerations need to be made if one part of this deployment breaks, but not another part.
+* If the new consumer is supporting a backend service that is not yet deployed using Kubernetes, for example, as an AWS instance, care must be taken to ensure consumers are deployed with the rest of the app. Considerations need to be made if one part of this deployment breaks, but not another.
 
 Rejected Alternatives
 ---------------------


### PR DESCRIPTION
Adds some additional notes about this decision based
on some discussions. Clarifies some of the potential
complexities around deployments.