### PR TITLE
temp: test workflow to create Jira tickets from labeled issues

### DIFF
--- a/.github/workflows/escalate.yml
+++ b/.github/workflows/escalate.yml
@@ -4,7 +4,6 @@ on: [pull_request, workflow_dispatch]
 
 jobs:
   file-jira:
-    if: ${{ github.event.label.name == 'escalate-to-psre' }}
     runs-on: ubuntu-latest
     steps:
       - name: Login
@@ -18,6 +17,6 @@ jobs:
         with:
           project: ARCHBOM
           issuetype: Task
-          summary: ${{ github.event.issue.title }}
-          description: ${{ github.event.issue.body }}
+          summary: rgraber is still testing things, ignore
+          description: ignore me
           fields: { "labels": "dos-request" }

--- a/.github/workflows/escalate.yml
+++ b/.github/workflows/escalate.yml
@@ -1,6 +1,9 @@
 name: Escalate to pSRE
 
-on: [pull_request, workflow_dispatch]
+on:
+  - issues:
+      types:
+        - labeled
 
 jobs:
   file-jira:
@@ -15,8 +18,8 @@ jobs:
       - name: Create ticket
         uses: atlassian/gajira-create@v3
         with:
-          project: PSRE
+          project: ARCHBOM
           issuetype: Story
-          summary: rgraber is testing things, ignore this
-          description: ignore me. if rgraber doesn't close this you can yell at her.
+          summary: ${{ github.event.issue.title }}
+          description: ${{ github.event.issue.body }}
           fields: '{ "labels": ["dos-request"] }'

--- a/.github/workflows/escalate.yml
+++ b/.github/workflows/escalate.yml
@@ -15,8 +15,8 @@ jobs:
       - name: Create ticket
         uses: atlassian/gajira-create@v3
         with:
-          project: ARCHBOM
+          project: PSRE
           issuetype: Task
-          summary: rgraber is still testing things, ignore
-          description: ignore me
+          summary: rgraber is testing things, ignore this
+          description: ignore me. if rgraber doesn't close this you can yell at her. 
           fields: '{ "labels": ["dos-request"], "customfield_10008": "PSRE-1950" }'

--- a/.github/workflows/escalate.yml
+++ b/.github/workflows/escalate.yml
@@ -1,9 +1,6 @@
 name: Escalate to pSRE
 
-on:
-  - issues:
-      types:
-        - labeled
+on: [pull_request, workflow_dispatch]
 
 jobs:
   file-jira:
@@ -23,3 +20,4 @@ jobs:
           issuetype: Task
           summary: ${{ github.event.issue.title }}
           description: ${{ github.event.issue.body }}
+          fields: { "labels": "dos-request" }

--- a/.github/workflows/escalate.yml
+++ b/.github/workflows/escalate.yml
@@ -19,4 +19,4 @@ jobs:
           issuetype: Task
           summary: rgraber is still testing things, ignore
           description: ignore me
-          fields: '{ "labels": ["dos-request"] }'
+          fields: '{ "labels": ["dos-request"], "customfield_10008": "PSRE-1950" }'

--- a/.github/workflows/escalate.yml
+++ b/.github/workflows/escalate.yml
@@ -1,0 +1,25 @@
+name: Escalate to pSRE
+
+on:
+  - issues:
+      types:
+        - labeled
+
+jobs:
+  file-jira:
+    if: ${{ github.event.label.name == 'escalate-to-psre' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Login
+        uses: atlassian/gajira-login@v3
+        env:
+          JIRA_BASE_URL: ${{ secrets.JIRA_BASE_URL }}
+          JIRA_USER_EMAIL: 'rgraber@edx.org'
+          JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
+      - name: Create ticket
+        uses: atlassian/gajira-create@v3
+        with:
+          project: ARCHBOM
+          issuetype: Task
+          summary: ${{ github.event.issue.title }}
+          description: ${{ github.event.issue.body }}

--- a/.github/workflows/escalate.yml
+++ b/.github/workflows/escalate.yml
@@ -19,4 +19,4 @@ jobs:
           issuetype: Task
           summary: rgraber is still testing things, ignore
           description: ignore me
-          fields: { "labels": "dos-request" }
+          fields: '{ "labels": "dos-request" }'

--- a/.github/workflows/escalate.yml
+++ b/.github/workflows/escalate.yml
@@ -22,4 +22,4 @@ jobs:
           issuetype: Story
           summary: ${{ github.event.issue.title }}
           description: ${{ github.event.issue.body }}
-          fields: '{ "labels": ["dos-request"] }'
+          fields: '{ "labels": ["esre-request"] }'

--- a/.github/workflows/escalate.yml
+++ b/.github/workflows/escalate.yml
@@ -16,7 +16,7 @@ jobs:
         uses: atlassian/gajira-create@v3
         with:
           project: PSRE
-          issuetype: Task
+          issuetype: Story
           summary: rgraber is testing things, ignore this
-          description: ignore me. if rgraber doesn't close this you can yell at her. 
-          fields: '{ "labels": ["dos-request"], "customfield_10008": "PSRE-1950" }'
+          description: ignore me. if rgraber doesn't close this you can yell at her.
+          fields: '{ "labels": ["dos-request"] }'

--- a/.github/workflows/escalate.yml
+++ b/.github/workflows/escalate.yml
@@ -19,4 +19,4 @@ jobs:
           issuetype: Task
           summary: rgraber is still testing things, ignore
           description: ignore me
-          fields: '{ "labels": "dos-request" }'
+          fields: '{ "labels": ["dos-request"] }'


### PR DESCRIPTION
This is meant to be a way to test an initial implementation of https://github.com/edx/edx-arch-experiments/issues/119 since I don't think I can trigger a branch workflow by labeling an issue.

Will revert once I verify that it works, and then 
1. get a service account
2. replace my email and token with said account
3. update to file issues to PSRE instead of ARCHBOM