### PR TITLE
feat: use new service account in escalate action

### DIFF
--- a/.github/workflows/escalate.yml
+++ b/.github/workflows/escalate.yml
@@ -13,7 +13,7 @@ jobs:
         uses: atlassian/gajira-login@v3
         env:
           JIRA_BASE_URL: ${{ secrets.JIRA_BASE_URL }}
-          JIRA_USER_EMAIL: 'rgraber@edx.org'
+          JIRA_USER_EMAIL: 'productivitysysops@2u.com'
           JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
       - name: Create ticket
         uses: atlassian/gajira-create@v3


### PR DESCRIPTION
Issue: https://github.com/edx/edx-arch-experiments/issues/119

The user is recently created by IT and the scope of what we should use it for is not 100% determined but @nedbat and I determined that it makes sense to use it here.