### PR TITLE
fix: escalate to PSRE instead of ARCHBOM

### DIFF
--- a/.github/workflows/escalate.yml
+++ b/.github/workflows/escalate.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Create ticket
         uses: atlassian/gajira-create@v3
         with:
-          project: ARCHBOM
+          project: PSRE
           issuetype: Story
           summary: ${{ github.event.issue.title }}
           description: ${{ github.event.issue.body }}


### PR DESCRIPTION
Issue: https://github.com/edx/edx-arch-experiments/issues/119
Fix escalate action to create in PSRE instead of ARCHBOM project. ARCHBOM was originally used to test the flow but PSRE is the correct destination.