### PR TITLE
feat: trigger summary block on any video, remove content pointer

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,12 @@ Unreleased
 ~~~~~~~~~~
 *
 
+[1.2.0] - 2023-05-08
+~~~~~~~~~~~~~~~~~~~~
+
+* Update summary hook to trigger on videos
+* Remove text selection data key from summary hook html
+
 [1.1.4] - 2023-04-14
 ~~~~~~~~~~~~~~~~~~~~
 

--- a/edx_arch_experiments/__init__.py
+++ b/edx_arch_experiments/__init__.py
@@ -2,4 +2,4 @@
 A plugin to include applications under development by the architecture team at 2U.
 """
 
-__version__ = '1.1.4'
+__version__ = '1.2.0'

--- a/edx_arch_experiments/summaryhook_aside/block.py
+++ b/edx_arch_experiments/summaryhook_aside/block.py
@@ -13,7 +13,6 @@ summary_fragment = """
   <div summary-launch>
     <div id="launch-summary-button"
       data-url-api="{{data_url_api}}"
-      data-text-identifier="{{data_text_identifier}}"
       data-course-id="{{data_course_id}}"
       data-content-id="{{data_content_id}}"
     >
@@ -37,13 +36,16 @@ def _children_have_summarizable_content(block):
     """
     children = block.get_children()
     for child in children:
+        category = getattr(child, 'category', None)
         if (
-                getattr(child, 'category', None) == 'html'
+                category == 'html'
                 and hasattr(child, 'get_html')
                 and len(child.get_html()) > settings.SUMMARY_HOOK_MIN_SIZE
         ):
             return True
-
+        # we will eventually require there to be transcripts available to trigger but not yet
+        if category == 'video':
+            return True
     return False
 
 
@@ -66,7 +68,6 @@ class SummaryHookAside(XBlockAside):
             _render_summary(
                 {
                     'data_url_api': settings.SUMMARY_HOOK_HOST,
-                    'data_text_identifier': '.xblock-student_view-html',
                     'data_course_id': block.scope_ids.usage_id.course_key,
                     'data_content_id': block.scope_ids.usage_id,
                     'js_url': settings.SUMMARY_HOOK_HOST + settings.SUMMARY_HOOK_JS_PATH,


### PR DESCRIPTION
We will be building a path for ai-spot to get content from edx rather than having it pushed by the browser, including video transcripts.

To demo that quickly we're going to populate selected course content into a temp store in ai-spot and it will fetch from a local fake edx.

So this change removes the local content indicator and triggers on any video and summaries will for a while only work on the pre-fetched while we catch up the rest of the content path.

Tested locally to verify appearance of aside div.


**Merge checklist:**
Check off if complete *or* not applicable:
- [x] Version bumped
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [x] Fixup commits are squashed away
- [x] Unit tests added/updated
- [x] Manual testing instructions provided
- [x] Noted any: Concerns, dependencies, migration issues, deadlines, tickets
