### PR TITLE
fix: upgrade pyyaml to fix requirements

### DIFF
--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -134,7 +134,7 @@ pytz==2023.3
     #   -r requirements/test.txt
     #   babel
     #   django
-pyyaml==6.0
+pyyaml==6.0.1
     # via
     #   -r requirements/test.txt
     #   code-annotations

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -181,7 +181,7 @@ pytz==2023.3
     # via
     #   -r requirements/test.txt
     #   django
-pyyaml==6.0
+pyyaml==6.0.1
     # via
     #   -r requirements/test.txt
     #   code-annotations

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -82,7 +82,7 @@ pytz==2023.3
     # via
     #   -r requirements/base.txt
     #   django
-pyyaml==6.0
+pyyaml==6.0.1
     # via code-annotations
 sqlparse==0.4.4
     # via


### PR DESCRIPTION
Update pyyaml to 6.0.1 to bring in a bugfix that was causing errors in make upgrade.
**Merge checklist:**
Check off if complete *or* not applicable:
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Fixup commits are squashed away
- [ ] Unit tests added/updated
- [ ] Manual testing instructions provided
- [ ] Noted any: Concerns, dependencies, migration issues, deadlines, tickets
