### PR TITLE
feat: add edx_recommendations to generate_code_owner_mappings.py

### DIFF
--- a/edx_arch_experiments/scripts/generate_code_owner_mappings.py
+++ b/edx_arch_experiments/scripts/generate_code_owner_mappings.py
@@ -33,6 +33,7 @@ EDX_REPO_APPS = {
     'csrf': 'https://github.com/openedx/edx-drf-extensions',
     'edx_name_affirmation': 'https://github.com/edx/edx-name-affirmation',
     'edx_proctoring': 'https://github.com/openedx/edx-proctoring',
+    'edx_recommendations': 'https://github.com/edx/edx-recommendations',
     'edxval': 'https://github.com/openedx/edx-val',
     'enterprise': 'https://github.com/openedx/edx-enterprise',
     'enterprise_learner_portal': 'https://github.com/openedx/edx-enterprise',


### PR DESCRIPTION
Fixes missing code_owner for:
- `"code_owner_module": "edx_recommendations.api.course_recommendations",`
- `"name": "WebTransaction/Function/edx_recommendations.api.course_recommendations:LearnerDashboardRecommendationsView.get",`

**Merge checklist:**
Check off if complete *or* not applicable:
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Fixup commits are squashed away
- [ ] Unit tests added/updated
- [ ] Manual testing instructions provided
- [ ] Noted any: Concerns, dependencies, migration issues, deadlines, tickets
