### PR TITLE
feat: abstract out producer creation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -4,13 +4,13 @@ edx-arch-experiments
 |pypi-badge| |ci-badge| |codecov-badge| |pyversions-badge|
 |license-badge|
 
-A plugin to include applications under development by the architecture team at 2U.
+A plugin to include applications under development by and useful utility scripts for the architecture team at 2U.
 
 Overview
 ------------------------
 
 This plugin is meant to house experimental and in-development applications from the edX architecture team at 2U that are either not appropriate (i.e. 2U-specific) or not yet ready for community consumption.
-
+It also includes some one-off scripts meant to reduce toil for the team.
 
 Development Workflow
 --------------------

--- a/edx_arch_experiments/scripts/republish_failed_events.py
+++ b/edx_arch_experiments/scripts/republish_failed_events.py
@@ -31,13 +31,14 @@ from ast import literal_eval
 import click
 from edx_event_bus_kafka.internal.producer import create_producer
 from openedx_events.tooling import EventsMetadata, OpenEdxPublicSignal, load_all_signals
+from openedx_events.event_bus import get_producer
 
 
 @click.command()
 @click.option('--filename', type=click.Path(exists=True))
 def read_and_send_events(filename):
     load_all_signals()
-    producer = create_producer()
+    producer = get_producer()
     try:
         log_columns = ['initial_topic', 'event_type', 'event_data_as_json', 'event_key_field', 'event_metadata_as_json']
         with open(filename) as log_file:

--- a/edx_arch_experiments/scripts/republish_failed_events.py
+++ b/edx_arch_experiments/scripts/republish_failed_events.py
@@ -29,8 +29,8 @@ import sys
 from ast import literal_eval
 
 import click
-from openedx_events.tooling import EventsMetadata, OpenEdxPublicSignal, load_all_signals
 from openedx_events.event_bus import get_producer
+from openedx_events.tooling import EventsMetadata, OpenEdxPublicSignal, load_all_signals
 
 
 @click.command()

--- a/edx_arch_experiments/scripts/republish_failed_events.py
+++ b/edx_arch_experiments/scripts/republish_failed_events.py
@@ -29,7 +29,6 @@ import sys
 from ast import literal_eval
 
 import click
-from edx_event_bus_kafka.internal.producer import create_producer
 from openedx_events.tooling import EventsMetadata, OpenEdxPublicSignal, load_all_signals
 from openedx_events.event_bus import get_producer
 


### PR DESCRIPTION
feat: abstract out the producer when republishing events

Use openedx-events.get_producer() instead of calling event bus kafka directly so it can be used with redis or other implementations.

**Merge checklist:**
Check off if complete *or* not applicable:
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Fixup commits are squashed away
- [ ] Unit tests added/updated
- [ ] Manual testing instructions provided
- [ ] Noted any: Concerns, dependencies, migration issues, deadlines, tickets
