### PR TITLE
feat: docker-based local work without lms

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,98 @@
+# Docker in this repo is only supported for running tests locally
+# as an alternative to virtualenv natively - johnnagro 2023-09-06
+FROM ubuntu:focal as app
+LABEL org.opencontainers.image.authors="sre@edx.org"
+
+
+# Packages installed:
+# git; Used to pull in particular requirements from github rather than pypi,
+# and to check the sha of the code checkout.
+
+# build-essentials; so we can use make with the docker container
+
+# language-pack-en locales; ubuntu locale support so that system utilities have a consistent
+# language and time zone.
+
+# python; ubuntu doesnt ship with python, so this is the python we will use to run the application
+
+# python3-pip; install pip to install application requirements.txt files
+
+# pkg-config
+#     mysqlclient>=2.2.0 requires this (https://github.com/PyMySQL/mysqlclient/issues/620)
+
+# libmysqlclient-dev; to install header files needed to use native C implementation for
+# MySQL-python for performance gains.
+
+# libssl-dev; # mysqlclient wont install without this.
+
+# python3-dev; to install header files for python extensions; much wheel-building depends on this
+
+# gcc; for compiling python extensions distributed with python packages like mysql-client
+
+# If you add a package here please include a comment above describing what it is used for
+RUN apt-get update && apt-get -qy install --no-install-recommends \
+ language-pack-en \
+ locales \
+ python3.8 \
+ python3-pip \
+ python3.8-venv \
+ pkg-config \
+ libmysqlclient-dev \
+ libssl-dev \
+ python3-dev \
+ gcc \
+ build-essential \
+ git \
+ curl
+
+
+RUN pip install --upgrade pip setuptools
+# delete apt package lists because we do not need them inflating our image
+RUN rm -rf /var/lib/apt/lists/*
+
+RUN ln -s /usr/bin/python3 /usr/bin/python
+
+RUN locale-gen en_US.UTF-8
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US:en
+ENV LC_ALL en_US.UTF-8
+ENV DJANGO_SETTINGS_MODULE test_settings
+
+# Env vars: path
+ENV VIRTUAL_ENV='/edx/app/venvs/edx-arch-experiments'
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+ENV PATH="/edx/app/edx-arch-experiments/node_modules/.bin:${PATH}"
+ENV PATH="/edx/app/edx-arch-experiments/bin:${PATH}"
+ENV PATH="/edx/app/nodeenv/bin:${PATH}"
+
+RUN useradd -m --shell /bin/false app
+
+WORKDIR /edx/app/edx-arch-experiments
+
+RUN python3.8 -m venv $VIRTUAL_ENV
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+
+# Copy the requirements explicitly even though we copy everything below
+# this prevents the image cache from busting unless the dependencies have changed.
+COPY requirements/ /edx/app/edx-arch-experiments/requirements/
+
+# Dependencies are installed as root so they cannot be modified by the application user.
+RUN pip install -r requirements/dev.txt
+RUN pip install nodeenv
+
+# Set up a Node environment and install Node requirements.
+# Must be done after Python requirements, since nodeenv is installed
+# via pip.
+# The node environment is already 'activated' because its .../bin was put on $PATH.
+RUN nodeenv /edx/app/nodeenv --node=18.15.0 --prebuilt
+
+RUN mkdir -p /edx/var/log
+
+# Code is owned by root so it cannot be modified by the application user.
+# So we copy it before changing users.
+USER app
+
+# This line is after the requirements so that changes to the code will not
+# bust the image cache
+COPY . /edx/app/edx-arch-experiments
+

--- a/Makefile
+++ b/Makefile
@@ -105,3 +105,8 @@ dummy_translations: ## generate dummy translation (.po) files
 build_dummy_translations: extract_translations dummy_translations compile_translations ## generate and compile dummy translation files
 
 validate_translations: build_dummy_translations detect_changed_source_translations ## validate translations
+
+## Docker in this repo is only supported for running tests locally
+## as an alternative to virtualenv natively - johnnagro 2023-09-06
+test-shell: ## Run a shell, as root, on the specified service container
+	docker-compose run -u 0 test-shell env TERM=$(TERM) /bin/bash

--- a/README.rst
+++ b/README.rst
@@ -28,7 +28,11 @@ One Time Setup
 
 Local testing
 ~~~~~~~~~~~~~
-To test your changes locally, you will need to install the package from your local branch into edx-platform. For example, if using devstack, copy or clone your branch into <devstack-parent>/src/edx-arch-experiments. Then, in an lms or cms shell, run ``pip install -e /edx/src/edx-arch-experiments``.  The plug-in configuration will automatically be picked up once installed, and changes will be hot reloaded.
+Two options are available for testing changes locally:
+
+First, via `make test-shell` a dockerized development envrionment can be launched to run `pytest` and do basic migration work.
+
+Second, a local copy of the package can be installed into edx-platform. For example, if using devstack, copy or clone your branch into <devstack-parent>/src/edx-arch-experiments. Then, in an lms or cms shell, run ``pip install -e /edx/src/edx-arch-experiments``.  The plug-in configuration will automatically be picked up once installed, and changes will be hot reloaded.
 
 
 Every time you develop something in this repo

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,24 @@
+# Docker in this repo is only supported for running tests locally
+# as an alternative to virtualenv natively - johnnagro 2023-09-06
+version: "2.1"
+services:
+  test-shell:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: arch-experiments.test.app
+    hostname: app.test.arch-experiments
+    volumes:
+      - .:/edx/app/edx-arch-experiments
+
+    networks:
+      - devstack_default
+    # Allows attachment to this container using 'docker attach <containerID>'.
+    stdin_open: true
+    tty: true
+    environment:
+      DJANGO_SETTINGS_MODULE: test_settings
+
+networks:
+  devstack_default:
+    external: true


### PR DESCRIPTION
### TLDR

Adds a `make test-shell` which launches a dockerized version of the local dev environment - rather than using a local virtualenv.

### Description

~ Working from https://github.com/openedx/edx-enterprise/pull/1467 ~

There are sometimes benefits and conveniences to having a containerized local environment versus setting up and maintaining python, virtualenv, and system dependencies (mysql-dev, etc) natively. Sometimes installing your code into the LMS container extends your testing cycle past your patience. Here is some docker/makefile config to enable make test-shell to launch a containerized environment containing your local development code so you can make test / make upgrade / 'profit' / etc inside a container.

### Action!

**pytest**
```
ubuntu@ip-172-31-38-188:~/edx-repos/edx-arch-experiments$ make test-shell
docker-compose run -u 0 test-shell env TERM=xterm-256color /bin/bash
root@app:/edx/app/edx-arch-experiments# ls
CHANGELOG.rst       Dockerfile            edx_arch_experiments.egg-info  manage.py     pylintrc         README.rst    setup.py
codecov.yml         docs                  LICENSE.txt                    MANIFEST.in   pylintrc_backup  requirements  test_settings.py
docker-compose.yml  edx_arch_experiments  Makefile                       openedx.yaml  pylintrc_tweaks  setup.cfg     tox.ini
root@app:/edx/app/edx-arch-experiments# pytest
================================================================== test session starts ===================================================================
platform linux -- Python 3.8.10, pytest-7.4.0, pluggy-1.2.0
django: settings: test_settings (from env)
rootdir: /edx/app/edx-arch-experiments
configfile: tox.ini
plugins: django-4.5.2, cov-4.1.0
collected 1 item                                                                                                                                         

edx_arch_experiments/tests/test_stub.py .                                                                                                          [100%]

---------- coverage: platform linux, python 3.8.10-final-0 -----------
Name                                          Stmts   Miss  Cover   Missing
---------------------------------------------------------------------------
edx_arch_experiments/__init__.py                  1      0   100%
edx_arch_experiments/apps.py                      5      0   100%
edx_arch_experiments/settings/__init__.py         0      0   100%
edx_arch_experiments/settings/common.py           2      2     0%   6-7
edx_arch_experiments/settings/production.py       2      2     0%   4-5
edx_arch_experiments/settings/scripts.py          4      4     0%   4-8
edx_arch_experiments/tests/test_stub.py           1      0   100%
---------------------------------------------------------------------------
TOTAL                                            15      8    47%
Coverage XML written to file coverage.xml


=================================================================== 1 passed in 0.14s ====================================================================
root@app:/edx/app/edx-arch-experiments#
```

**make validate**
```
ubuntu@ip-172-31-38-188:~/edx-repos/edx-arch-experiments$ make test-shell
docker-compose run -u 0 test-shell env TERM=xterm-256color /bin/bash
root@app:/edx/app/edx-arch-experiments# make validate
tox -e quality
GLOB sdist-make: /edx/app/edx-arch-experiments/setup.py
quality inst-nodeps: /edx/app/edx-arch-experiments/.tox/.tmp/package/1/edx-arch-experiments-2.0.0.zip
quality installed: asgiref==3.7.2,astroid==2.15.6,bleach==6.0.0,certifi==2023.5.7,cffi==1.15.1,charset-normalizer==3.2.0,click==8.1.5,click-log==0.4.0,code-annotations==1.3.0,coverage==7.2.7,cryptography==41.0.2,dill==0.3.6,Django==3.2.20,django-crum==0.7.9,django-waffle==3.0.0,docutils==0.20.1,edx-arch-experiments @ file:///edx/app/edx-arch-experiments/.tox/.tmp/package/1/edx-arch-experiments-2.0.0.zip#sha256=a10aea254751c177b241f25962cbc75e226602ab2e823a8e42297e3437284c51,edx-django-utils==5.5.0,edx-lint==5.3.4,exceptiongroup==1.1.2,idna==3.4,importlib-metadata==6.8.0,importlib-resources==6.0.0,iniconfig==2.0.0,isort==5.12.0,jaraco.classes==3.3.0,jeepney==0.8.0,Jinja2==3.1.2,keyring==24.2.0,lazy-object-proxy==1.9.0,markdown-it-py==3.0.0,MarkupSafe==2.1.3,mccabe==0.7.0,mdurl==0.1.2,more-itertools==9.1.0,newrelic==8.8.1,packaging==23.1,pbr==5.11.1,pkginfo==1.9.6,platformdirs==3.9.1,pluggy==1.2.0,psutil==5.9.5,pycodestyle==2.10.0,pycparser==2.21,pydocstyle==6.3.0,Pygments==2.15.1,pylint==2.17.4,pylint-celery==0.3,pylint-django==2.5.3,pylint-plugin-utils==0.8.2,PyNaCl==1.5.0,pytest==7.4.0,pytest-cov==4.1.0,pytest-django==4.5.2,python-slugify==8.0.1,pytz==2023.3,PyYAML==6.0.1,readme-renderer==40.0,requests==2.31.0,requests-toolbelt==1.0.0,rfc3986==2.0.0,rich==13.4.2,SecretStorage==3.3.3,six==1.16.0,snowballstemmer==2.2.0,sqlparse==0.4.4,stevedore==5.1.0,text-unidecode==1.3,tomli==2.0.1,tomlkit==0.11.8,twine==4.0.2,typing_extensions==4.7.1,urllib3==2.0.3,webencodings==0.5.1,wrapt==1.15.0,zipp==3.16.2
quality run-test-pre: PYTHONHASHSEED='728355740'
quality run-test: commands[0] | pylint edx_arch_experiments manage.py setup.py
quality run-test: commands[1] | pycodestyle edx_arch_experiments manage.py setup.py
quality run-test: commands[2] | pydocstyle edx_arch_experiments manage.py setup.py
quality run-test: commands[3] | isort --check-only --diff edx_arch_experiments manage.py setup.py test_settings.py
quality run-test: commands[4] | make selfcheck
The Makefile is well-formed.
________________________________________________________________________ summary _________________________________________________________________________
  quality: commands succeeded
  congratulations :)
tox -e pii_check
ERROR: unknown environment 'pii_check'
make: *** [Makefile:63: pii_check] Error 1
root@app:/edx/app/edx-arch-experiments#
```

