### PR TITLE
feat: Add ora2 openassessment mapping

### DIFF
--- a/edx_arch_experiments/scripts/generate_code_owner_mappings.py
+++ b/edx_arch_experiments/scripts/generate_code_owner_mappings.py
@@ -44,6 +44,7 @@ EDX_REPO_APPS = {
     'learning_assistant': 'https://github.com/edx/learning-assistant',
     'lti_consumer': 'https://github.com/openedx/xblock-lti-consumer',
     'notices': 'https://github.com/edx/platform-plugin-notices',
+    'openassessment': 'https://github.com/openedx/edx-ora2',
     'ora2': 'https://github.com/openedx/edx-ora2',
     'organizations': 'https://github.com/openedx/edx-organizations',
     'search': 'https://github.com/openedx/edx-search',


### PR DESCRIPTION
We're getting alerts for Celery transactions with a `code_owner_module` of `openassessment.workflow.tasks` but no mapped code owner. While `openassessment` isn't an app, this might be the right way to fix this?

**Merge checklist:**
Check off if complete *or* not applicable:
- [x] Version bumped
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [x] Fixup commits are squashed away
- [x] Unit tests added/updated
- [x] Manual testing instructions provided
- [x] Noted any: Concerns, dependencies, migration issues, deadlines, tickets
