### PR TITLE
feat!: Rename ConfigWatcher app and configure as plugin; reduce fields

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,15 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+[3.0.0] - 2023-10-30
+~~~~~~~~~~~~~~~~~~~~
+
+Changed
+_______
+
+* Renamed ``ConfigWatcherApp`` to ``ConfigWatcher`` to be less redundant. This is technically a breaking change but the app was not in use yet.
+* Enabled ``ConfigWatcher`` as a plugin for LMS
+
 [2.2.0] - 2023-10-27
 ~~~~~~~~~~~~~~~~~~~~
 

--- a/edx_arch_experiments/__init__.py
+++ b/edx_arch_experiments/__init__.py
@@ -2,4 +2,4 @@
 A plugin to include applications under development by the architecture team at 2U.
 """
 
-__version__ = '2.2.0'
+__version__ = '3.0.0'

--- a/edx_arch_experiments/config_watcher/apps.py
+++ b/edx_arch_experiments/config_watcher/apps.py
@@ -5,11 +5,14 @@ App for reporting configuration changes to Slack for operational awareness.
 from django.apps import AppConfig
 
 
-class ConfigWatcherApp(AppConfig):
+class ConfigWatcher(AppConfig):
     """
     Django application to report configuration changes to operators.
     """
     name = 'edx_arch_experiments.config_watcher'
+
+    # Mark this as a plugin app
+    plugin_app = {}
 
     def ready(self):
         from .signals import receivers  # pylint: disable=import-outside-toplevel

--- a/edx_arch_experiments/config_watcher/signals/receivers.py
+++ b/edx_arch_experiments/config_watcher/signals/receivers.py
@@ -75,7 +75,7 @@ _WAFFLE_MODELS_TO_OBSERVE = [
     {
         'model': waffle.models.Flag,
         'short_name': 'flag',
-        'fields': ['everyone', 'percent', 'superusers', 'staff', 'authenticated', 'note', 'languages'],
+        'fields': ['everyone', 'percent', 'note'],
     },
     {
         'model': waffle.models.Switch,

--- a/setup.py
+++ b/setup.py
@@ -162,6 +162,7 @@ setup(
     entry_points={
         "lms.djangoapp": [
             "arch_experiments = edx_arch_experiments.apps:EdxArchExperimentsConfig",
+            "config_watcher = edx_arch_experiments.config_watcher.apps:ConfigWatcher",
         ],
     },
 )


### PR DESCRIPTION
- ConfigWatcher needs to be configured as a plugin to be loaded into edxapp, since we don't use INSTALLED_APPS for this dependency.
- On the renaming: This is the name I actually meant to write in the first place.
- Remove some fields that are less likely to be interesting and are likely to just result in clutter.

----

Re-tested in devstack. This time, I only had to add the `CONFIG_WATCHER_SLACK_WEBHOOK_URL` setting in order for the plugin to activate -- no need to add to INSTALLED_APPS.

----

**Merge checklist:**
Check off if complete *or* not applicable:
- [x] Version bumped
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [x] Fixup commits are squashed away
- [x] Unit tests added/updated
- [x] Manual testing instructions provided
- [x] Noted any: Concerns, dependencies, migration issues, deadlines, tickets
