### PR TITLE
feat: Log addition of config watchers and make receivers unique

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,15 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+[3.1.0] - 2023-10-31
+~~~~~~~~~~~~~~~~~~~~
+
+Changed
+_______
+
+* Add log message for each model the ConfigWatcher is listening to
+* Ensure that ConfigWatcher only attaches receivers once
+
 [3.0.0] - 2023-10-30
 ~~~~~~~~~~~~~~~~~~~~
 

--- a/edx_arch_experiments/__init__.py
+++ b/edx_arch_experiments/__init__.py
@@ -2,4 +2,4 @@
 A plugin to include applications under development by the architecture team at 2U.
 """
 
-__version__ = '3.0.0'
+__version__ = '3.1.0'


### PR DESCRIPTION
- Add log message for each model the ConfigWatcher is listening to, mostly so I can tell whether this app is even getting loaded.
- Add dispatch_uid to receivers so that if `ready` (or `connect_receivers`) is called more than once, the receiver is only attached once. (This is not a response to an observed problem -- it's just a best practice according to Django docs.)


**Merge checklist:**
Check off if complete *or* not applicable:
- [x] Version bumped
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [x] Fixup commits are squashed away
- [x] Unit tests added/updated
- [x] Manual testing instructions provided
- [x] Noted any: Concerns, dependencies, migration issues, deadlines, tickets
