### PR TITLE
feat: Enable ConfigWatcher in CMS; prefix Slack messages with IDA name

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,13 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+[3.3.0] - 2024-01-23
+~~~~~~~~~~~~~~~~~~~~
+Changed
+_______
+* Updated ``ConfigWatcher`` to include the IDA's name in change messages if ``CONFIG_WATCHER_SERVICE_NAME`` is set
+* Enabled ``ConfigWatcher`` as a plugin for CMS
+
 [3.2.0] - 2024-01-11
 ~~~~~~~~~~~~~~~~~~~~
 Added

--- a/edx_arch_experiments/__init__.py
+++ b/edx_arch_experiments/__init__.py
@@ -2,4 +2,4 @@
 A plugin to include applications under development by the architecture team at 2U.
 """
 
-__version__ = '3.2.0'
+__version__ = '3.3.0'

--- a/edx_arch_experiments/config_watcher/README.rst
+++ b/edx_arch_experiments/config_watcher/README.rst
@@ -1,0 +1,8 @@
+ConfigWatcher
+#############
+
+Plugin app that can report on changes to Django model instances via logging and optionally Slack messages. The goal is to help operators who are investigating an outage or other sudden change in behavior by allowing them to easily determine what has changed recently.
+
+Currently specialized to observe Waffle flags, switches, and samples, but could be expanded to other models.
+
+See ``.signals.receivers`` for available settings and ``/setup.py`` for IDA plugin configuration.

--- a/edx_arch_experiments/config_watcher/signals/tests/test_receivers.py
+++ b/edx_arch_experiments/config_watcher/signals/tests/test_receivers.py
@@ -1,0 +1,48 @@
+"""
+Test ConfigWatcher signal receivers (main code).
+"""
+
+import json
+from contextlib import ExitStack
+from unittest.mock import call, patch
+
+import ddt
+from django.test import TestCase, override_settings
+
+from edx_arch_experiments.config_watcher.signals import receivers
+
+
+@ddt.ddt
+class TestConfigWatcherReceivers(TestCase):
+
+    @ddt.unpack
+    @ddt.data(
+        (
+            None, None, None,
+        ),
+        (
+            'https://localhost', None, "test message",
+        ),
+        (
+            'https://localhost', 'my-ida', "[my-ida] test message",
+        ),
+    )
+    def test_send_to_slack(self, slack_url, service_name, expected_message):
+        """Check that message prefixing is performed as expected."""
+        # This can be made cleaner in Python 3.10
+        with ExitStack() as stack:
+            patches = [
+                patch('urllib.request.Request'),
+                patch('urllib.request.urlopen'),
+                patch.object(receivers, 'CONFIG_WATCHER_SLACK_WEBHOOK_URL', slack_url),
+                patch.object(receivers, 'CONFIG_WATCHER_SERVICE_NAME', service_name),
+            ]
+            (mock_req, _, _, _) = [stack.enter_context(cm) for cm in patches]
+            receivers._send_to_slack("test message")
+
+        if expected_message is None:
+            mock_req.assert_not_called()
+        else:
+            assert mock_req.called_once()
+            (call_args, call_kwargs) = mock_req.call_args_list[0]
+            assert json.loads(call_kwargs['data'])['text'] == expected_message

--- a/setup.py
+++ b/setup.py
@@ -165,5 +165,8 @@ setup(
             "config_watcher = edx_arch_experiments.config_watcher.apps:ConfigWatcher",
             "codejail_service = edx_arch_experiments.codejail_service.apps:CodejailService",
         ],
+        "cms.djangoapp": [
+            "config_watcher = edx_arch_experiments.config_watcher.apps:ConfigWatcher",
+        ],
     },
 )


### PR DESCRIPTION
Introduces `CONFIG_WATCHER_SERVER_NAME` to support messaging from multiple services.

**Merge checklist:**
Check off if complete *or* not applicable:
- [x] Version bumped
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [x] Fixup commits are squashed away
- [x] Unit tests added/updated
- [x] Manual testing instructions provided
- [x] Noted any: Concerns, dependencies, migration issues, deadlines, tickets
