### PR TITLE
ci: Switch to Trusted Publisher method for PyPI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,4 @@
-name: Publish package to PyPi
+name: Publish package to PyPI
 
 on:
   push:
@@ -6,17 +6,13 @@ on:
       - '*'
 
 jobs:
-
-  push:
-    runs-on: ubuntu-20.04
-
+  publish:
+    runs-on: ubuntu-22.04
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: setup python
-        uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
         with:
-          python-version: 3.11
+          python-version: '3.11'
 
       - name: Install pip
         run: pip install -r requirements/pip.txt
@@ -24,7 +20,7 @@ jobs:
       - name: Build package
         run: python setup.py sdist bdist_wheel
 
-      - name: Publish to PyPi
+      - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: __token__

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,6 +8,13 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-22.04
+
+    environment:
+      name: pypi
+      url: https://pypi.org/p/edx-arch-experiments
+    permissions:
+      id-token: write  # used by pypi-publish
+
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v4
@@ -22,6 +29,3 @@ jobs:
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          user: __token__
-          password: ${{ secrets.PYPI_UPLOAD_TOKEN }}

--- a/.github/workflows/test_publish.yml
+++ b/.github/workflows/test_publish.yml
@@ -1,22 +1,24 @@
-name: Test Publish
+name: Test-publish package to PyPI
 
 on:
   pull_request:
 
 jobs:
-  testing:
-    runs-on: ubuntu-latest
+  test-publish:
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v4
         with:
           python-version: '3.11'
-          architecture: x64
+
       - name: Install pip
         run: pip install -r requirements/pip.txt
+
       - name: Build package
         run: python setup.py sdist bdist_wheel
-      - name: Test publish
+
+      - name: Publish to PyPI (test server)
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: __token__

--- a/.github/workflows/test_publish.yml
+++ b/.github/workflows/test_publish.yml
@@ -6,6 +6,13 @@ on:
 jobs:
   test-publish:
     runs-on: ubuntu-22.04
+
+    environment:
+      name: testpypi
+      url: https://test.pypi.org/p/edx-arch-experiments
+    permissions:
+      id-token: write  # used by pypi-publish
+
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v4
@@ -21,8 +28,6 @@ jobs:
       - name: Publish to PyPI (test server)
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          user: __token__
-          password: ${{ secrets.PYPI_TEST_UPLOAD_TOKEN }}
           repository_url: https://test.pypi.org/legacy/
           skip_existing: true
 


### PR DESCRIPTION
Testing out the Trusted Publisher method for PyPI:
https://docs.pypi.org/trusted-publishers/

This should allow us to avoid using an org-wide secret, in favor of
short-lived tokens generated by GitHub.

Preceded by a refactor commit to clean up the workflow files first.

**Merge checklist:**
Check off if complete *or* not applicable:
- [x] Version bumped
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [x] Fixup commits are squashed away
- [x] Unit tests added/updated
- [x] Manual testing instructions provided
- [x] Noted any: Concerns, dependencies, migration issues, deadlines, tickets