### PR TITLE
fix: Remove early span-start logging; fix loading of Django settings

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,11 +14,22 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+[4.2.0] - 2024-08-13
+~~~~~~~~~~~~~~~~~~~~
+Fixed
+-----
+* Fixed loading of ``DATADOG_DIAGNOSTICS_ENABLE``, which was previously not loaded properly and therefore was always True. Also fixed loading of ``DATADOG_DIAGNOSTICS_MAX_SPANS``, which was presumably broken as well.
+
+Removed
+-------
+* Removed early span-start logging. It never worked properly, possibly because workers are continually being destroyed and created, leading to high log volume.
+
 [4.1.0] - 2024-08-09
 ~~~~~~~~~~~~~~~~~~~~
 Changed
 -------
 * Datadog diagnostics will now log all span-starts for the first minute after server startup
+* **WARNING**: Do not use this version; see 4.2.0 release notes.
 
 [4.0.0] - 2024-08-05
 ~~~~~~~~~~~~~~~~~~~~

--- a/edx_arch_experiments/__init__.py
+++ b/edx_arch_experiments/__init__.py
@@ -2,4 +2,4 @@
 A plugin to include applications under development by the architecture team at 2U.
 """
 
-__version__ = '4.1.0'
+__version__ = '4.2.0'

--- a/edx_arch_experiments/datadog_diagnostics/apps.py
+++ b/edx_arch_experiments/datadog_diagnostics/apps.py
@@ -3,39 +3,11 @@ App for emitting additional diagnostic information for the Datadog integration.
 """
 
 import logging
-import time
 
 from django.apps import AppConfig
 from django.conf import settings
 
 log = logging.getLogger(__name__)
-
-
-# .. toggle_name: DATADOG_DIAGNOSTICS_ENABLE
-# .. toggle_implementation: DjangoSetting
-# .. toggle_default: True
-# .. toggle_description: Enables logging of Datadog diagnostics information.
-# .. toggle_use_cases: circuit_breaker
-# .. toggle_creation_date: 2024-07-11
-# .. toggle_tickets: https://github.com/edx/edx-arch-experiments/issues/692
-DATADOG_DIAGNOSTICS_ENABLE = getattr(settings, 'DATADOG_DIAGNOSTICS_ENABLE', True)
-
-# .. setting_name: DATADOG_DIAGNOSTICS_MAX_SPANS
-# .. setting_default: 100
-# .. setting_description: Limit of how many spans to hold onto and log
-#   when diagnosing Datadog tracing issues. This limits memory consumption
-#   avoids logging more data than is actually needed for diagnosis.
-DATADOG_DIAGNOSTICS_MAX_SPANS = getattr(settings, 'DATADOG_DIAGNOSTICS_MAX_SPANS', 100)
-
-# .. setting_name: DATADOG_DIAGNOSTICS_LOG_ALL_SPAN_STARTS_PERIOD
-# .. setting_default: 60
-# .. setting_description: Log all span starts for this many seconds after worker
-#   startup.
-DATADOG_DIAGNOSTICS_LOG_ALL_SPAN_STARTS_PERIOD = getattr(
-    settings,
-    'DATADOG_DIAGNOSTICS_LOG_ALL_SPAN_STARTS_PERIOD',
-    60
-)
 
 
 # pylint: disable=missing-function-docstring
@@ -46,19 +18,18 @@ class MissingSpanProcessor:
         self.spans_started = 0
         self.spans_finished = 0
         self.open_spans = {}
-        self.log_all_until = time.time() + DATADOG_DIAGNOSTICS_LOG_ALL_SPAN_STARTS_PERIOD
+
+        # .. setting_name: DATADOG_DIAGNOSTICS_MAX_SPANS
+        # .. setting_default: 100
+        # .. setting_description: Limit of how many spans to hold onto and log
+        #   when diagnosing Datadog tracing issues. This limits memory consumption
+        #   avoids logging more data than is actually needed for diagnosis.
+        self.DATADOG_DIAGNOSTICS_MAX_SPANS = getattr(settings, 'DATADOG_DIAGNOSTICS_MAX_SPANS', 100)
 
     def on_span_start(self, span):
         self.spans_started += 1
-        if len(self.open_spans) < DATADOG_DIAGNOSTICS_MAX_SPANS:
+        if len(self.open_spans) < self.DATADOG_DIAGNOSTICS_MAX_SPANS:
             self.open_spans[span.span_id] = span
-
-        # We believe that the anomalous traces always come from a
-        # single span that is created early in the lifetime of a
-        # gunicorn worker. If we log *every* span-start in this early
-        # period, we may be able to observe something interesting.
-        if time.time() <= self.log_all_until:
-            log.info(f"Early span-start sample: {span._pprint()}")  # pylint: disable=protected-access
 
     def on_span_finish(self, span):
         self.spans_finished += 1
@@ -80,6 +51,15 @@ class DatadogDiagnostics(AppConfig):
     plugin_app = {}
 
     def ready(self):
+        # .. toggle_name: DATADOG_DIAGNOSTICS_ENABLE
+        # .. toggle_implementation: DjangoSetting
+        # .. toggle_default: True
+        # .. toggle_description: Enables logging of Datadog diagnostics information.
+        # .. toggle_use_cases: circuit_breaker
+        # .. toggle_creation_date: 2024-07-11
+        # .. toggle_tickets: https://github.com/edx/edx-arch-experiments/issues/692
+        DATADOG_DIAGNOSTICS_ENABLE = getattr(settings, 'DATADOG_DIAGNOSTICS_ENABLE', True)
+
         if not DATADOG_DIAGNOSTICS_ENABLE:
             return
 


### PR DESCRIPTION
I still don't understand why this setting loading was broken -- maybe there's something unusual about the way plugin apps are loaded?

This addresses https://github.com/edx/edx-arch-experiments/issues/771

**Merge checklist:**
Check off if complete *or* not applicable:
- [x] Version bumped
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [x] Fixup commits are squashed away
- [x] Unit tests added/updated
- [x] Manual testing instructions provided
- [x] Noted any: Concerns, dependencies, migration issues, deadlines, tickets
