### PR TITLE
feat: Add vendored release candidate of ddtrace that may fix celery spans

### DIFF
--- a/edx_arch_experiments/datadog_diagnostics/vendor/README.rst
+++ b/edx_arch_experiments/datadog_diagnostics/vendor/README.rst
@@ -1,0 +1,12 @@
+Vendored files for Datadog debugging
+####################################
+
+**Notice**: This directory contains files that are not covered under
+the repository license and have been copied from elsewhere for build
+and deploy convenience.
+
+Listing of files, their origin, and their purpose for inclusion:
+
+* ``ddtrace-*.whl``: `ddtrace <https://github.com/DataDog/dd-trace-py>`__
+
+  * ``ddtrace-2.14.0.dev106+g241ca66cf-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl`` is a CI build of `<https://github.com/DataDog/dd-trace-py/pull/10676>`__ (2024-09-23) for a possible root-cause fix for `<https://github.com/edx/edx-arch-experiments/issues/692>`__. It will be fetched from GitHub for edx-platform deploys at build time.


### PR DESCRIPTION
I picked this wheel because I see `EDXAPP_PYTHON_VERSION: "python3.11"` in the configuration repo, and no overrides. The wheel is the artifact named `wheels-cp311-manylinux_x86_64` from branch build
<https://github.com/DataDog/dd-trace-py/actions/runs/10997116239>.

**Merge checklist:**
Check off if complete *or* not applicable:
- [x] Version bumped
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [x] Fixup commits are squashed away
- [x] Unit tests added/updated
- [x] Manual testing instructions provided
- [x] Noted any: Concerns, dependencies, migration issues, deadlines, tickets
