### PR TITLE
feat: Add datadog-api-client to dev deps so script is easier to use

### DIFF
--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -7,3 +7,4 @@
 
 diff-cover                # Changeset diff test coverage
 edx-i18n-tools            # For i18n_tool dummy
+datadog-api-client        # Datadog client API for datadog_search.py

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -47,6 +47,7 @@ celery==5.4.0
 certifi==2024.8.30
     # via
     #   -r requirements/quality.txt
+    #   datadog-api-client
     #   requests
 cffi==1.17.1
     # via
@@ -109,6 +110,8 @@ cryptography==44.0.0
     #   -r requirements/quality.txt
     #   pyjwt
     #   secretstorage
+datadog-api-client==2.30.0
+    # via -r requirements/dev.in
 ddt==1.7.2
     # via -r requirements/quality.txt
 ddtrace==2.17.2
@@ -409,6 +412,7 @@ python-dateutil==2.9.0.post0
     # via
     #   -r requirements/quality.txt
     #   celery
+    #   datadog-api-client
 python-slugify==8.0.4
     # via
     #   -r requirements/quality.txt
@@ -493,6 +497,7 @@ twine==6.0.1
 typing-extensions==4.12.2
     # via
     #   -r requirements/quality.txt
+    #   datadog-api-client
     #   ddtrace
     #   edx-opaque-keys
 tzdata==2024.2
@@ -503,6 +508,7 @@ tzdata==2024.2
 urllib3==2.2.3
     # via
     #   -r requirements/quality.txt
+    #   datadog-api-client
     #   requests
     #   twine
 vine==5.1.0


### PR DESCRIPTION
It still makes sense for the script to explicitly call out this dependency in its --help message, but we can also install the dep automatically for people calling it from the context of a fully installed venv for this repo.

**Merge checklist:**
Check off if complete *or* not applicable:
- [ ] ~Version bumped~
- [ ] ~Changelog record added~
- [ ] ~Documentation updated (not only docstrings)~
- [ ] ~Fixup commits are squashed away~
- [ ] ~Unit tests added/updated~
- [ ] ~Manual testing instructions provided~
- [ ] ~Noted any: Concerns, dependencies, migration issues, deadlines, tickets~
