### PR TITLE
feat!: remove temporary rollout span tag code_owner_plugin

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,9 @@ Change Log
 
 Unreleased
 ~~~~~~~~~~
+Removed
+-------
+* Removed temporary rollout span tag ``code_owner_plugin`` used for the code owner monitoring move from edx-django-utils. Now that edx-django-utils monitoring has been disabled, this span tag serves no purpose.
 
 [6.1.0] - 2024-12-10
 ~~~~~~~~~~~~~~~~~~~~

--- a/edx_arch_experiments/datadog_monitoring/code_owner/utils.py
+++ b/edx_arch_experiments/datadog_monitoring/code_owner/utils.py
@@ -136,15 +136,6 @@ def set_code_owner_custom_span_tags(code_owner):
     #     to the code_owner span tag.
     set_custom_attribute('code_owner_squad', code_owner)
 
-    # .. custom_attribute_name: code_owner_plugin
-    # .. custom_attribute_description: This is a temporary span tag to roll out the
-    #     the switch from edx-django-utils to this plugin. If this span tag is True,
-    #     the plugin has added the above custom span tags (possibly in addition to
-    #     edx-django-utils). If the code_owner_theme span tag is also seen, then
-    #     edx-django-utils is also adding these span tags. If not, only the plugin is
-    #     creating these tags.
-    set_custom_attribute('code_owner_plugin', True)
-
 
 def set_code_owner_span_tags_from_request(request):
     """

--- a/edx_arch_experiments/datadog_monitoring/tests/code_owner/test_utils.py
+++ b/edx_arch_experiments/datadog_monitoring/tests/code_owner/test_utils.py
@@ -169,7 +169,6 @@ class MonitoringUtilsTests(TestCase):
         if code_owner:
             call_list.append(call('code_owner', code_owner))
             call_list.append(call('code_owner_squad', code_owner))
-            call_list.append(call('code_owner_plugin', True))
         if module:
             call_list.append(call('code_owner_module', module))
         if has_path_error:


### PR DESCRIPTION
The span tag code_owner_plugin was used to rollout code_owner switch from edx-django-utils to the
datadog_monitoring plugin in this repo. Now that
rollout is complete, this span tag can be removed.

Implements:
- https://github.com/edx/edx-arch-experiments/issues/784


**Merge checklist:**
Check off if complete *or* not applicable:
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Fixup commits are squashed away
- [ ] Unit tests added/updated
- [ ] Manual testing instructions provided
- [ ] Noted any: Concerns, dependencies, migration issues, deadlines, tickets
