### PR TITLE
fix: Correct module name for federated_content_connector

### DIFF
--- a/edx_arch_experiments/scripts/generate_code_owner_mappings.py
+++ b/edx_arch_experiments/scripts/generate_code_owner_mappings.py
@@ -42,7 +42,7 @@ EDX_REPO_APPS = {
     'enterprise': 'https://github.com/openedx/edx-enterprise',
     'enterprise_learner_portal': 'https://github.com/openedx/edx-enterprise',
     'eventtracking': 'https://github.com/openedx/event-tracking',
-    'federated-content-connector': 'https://github.com/edx/federated-content-connector',
+    'federated_content_connector': 'https://github.com/edx/federated-content-connector',
     'help_tokens': 'https://github.com/openedx/help-tokens',
     'integrated_channels': 'https://github.com/openedx/edx-enterprise',
     'learner_pathway_progress': 'https://github.com/edx/learner-pathway-progress',


### PR DESCRIPTION
Underscores instead of hyphens

**Merge checklist:**
Check off if complete *or* not applicable:
- [x] Version bumped
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [x] Fixup commits are squashed away
- [x] Unit tests added/updated
- [x] Manual testing instructions provided
- [x] Noted any: Concerns, dependencies, migration issues, deadlines, tickets
