### PR TITLE
feat: Add channel_integrations to ownership mapping

### DIFF
--- a/edx_arch_experiments/scripts/generate_code_owner_mappings.py
+++ b/edx_arch_experiments/scripts/generate_code_owner_mappings.py
@@ -29,6 +29,7 @@ import click
 # These applications are the ones which contain views we want to monitor
 EDX_REPO_APPS = {
     'bulk_grades': 'https://github.com/openedx/edx-bulk-grades',
+    'channel_integrations': 'https://github.com/openedx/enterprise-integrated-channels',
     'coaching': 'https://github.com/edx/platform-plugin-coaching',
     'completion': 'https://github.com/openedx/completion',
     'config_models': 'https://github.com/openedx/django-config-models',


### PR DESCRIPTION
`enterprise-integrated-channels` was recently added to edxapp's bundled.in.

**Merge checklist:**
Check off if complete *or* not applicable:
- [x] Version bumped
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [x] Fixup commits are squashed away
- [x] Unit tests added/updated
- [x] Manual testing instructions provided
- [x] Noted any: Concerns, dependencies, migration issues, deadlines, tickets
