### PR TITLE
chore: BOMS-39 rename arbi-bom to orbi-bom

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,4 +6,4 @@ updates:
     schedule:
         interval: "weekly"
     reviewers:
-      - "edx/arbi-bom"
+      - "edx/orbi-bom"

--- a/.github/workflows/upgrade-python-requirements.yml
+++ b/.github/workflows/upgrade-python-requirements.yml
@@ -17,7 +17,7 @@ jobs:
        branch: ${{ github.event.inputs.branch }}
        team_reviewers: "orbi-bom"
        email_address: orbi-bom-upgrade-prs@2u-internal.jsmalerts.atlassian.net
-       send_success_notification: false
+       send_success_notification: true
     secrets:
        requirements_bot_github_token: ${{ secrets.REQUIREMENTS_BOT_GITHUB_TOKEN }}
        requirements_bot_github_email: ${{ secrets.REQUIREMENTS_BOT_GITHUB_EMAIL }}

--- a/.github/workflows/upgrade-python-requirements.yml
+++ b/.github/workflows/upgrade-python-requirements.yml
@@ -15,8 +15,8 @@ jobs:
     uses: openedx/.github/.github/workflows/upgrade-python-requirements.yml@master
     with:
        branch: ${{ github.event.inputs.branch }}
-       team_reviewers: "arbi-bom"
-       email_address: arbi-bom@edx.org
+       team_reviewers: "orbi-bom"
+       email_address: orbi-bom@edx.org
        send_success_notification: false
     secrets:
        requirements_bot_github_token: ${{ secrets.REQUIREMENTS_BOT_GITHUB_TOKEN }}

--- a/.github/workflows/upgrade-python-requirements.yml
+++ b/.github/workflows/upgrade-python-requirements.yml
@@ -16,7 +16,7 @@ jobs:
     with:
        branch: ${{ github.event.inputs.branch }}
        team_reviewers: "orbi-bom"
-       email_address: orbi-bom@edx.org
+       email_address: orbi-bom-upgrade-prs@2u-internal.jsmalerts.atlassian.net
        send_success_notification: false
     secrets:
        requirements_bot_github_token: ${{ secrets.REQUIREMENTS_BOT_GITHUB_TOKEN }}


### PR DESCRIPTION
Description

Update GitHub workflow failure email notifications to use orbi-bom's JSM email instead of [arbi-bom@edx.org](mailto:arbi-bom@edx.org) 
Changes team reviewer assignments from arbi-bom to orbi-bom in dependency management workflows

Related PRs
https://github.com/edx/api-manager/pull/354
https://github.com/edx/devstack/pull/174
https://github.com/edx/edx-internal/pull/13377
https://github.com/edx/repo-health-data/pull/312
https://github.com/edx/jenkins-job-dsl-internal/pull/962

Jira - [BOMS-39](https://2u-internal.atlassian.net/browse/BOMS-39)

[BOMS-39]: https://2u-internal.atlassian.net/browse/BOMS-39