### PR TITLE
fix: mapping fixing for ownership sync

### DIFF
--- a/edx_arch_experiments/scripts/generate_code_owner_mappings.py
+++ b/edx_arch_experiments/scripts/generate_code_owner_mappings.py
@@ -30,7 +30,6 @@ import click
 EDX_REPO_APPS = {
     'bulk_grades': 'https://github.com/openedx/edx-bulk-grades',
     'channel_integrations': 'https://github.com/openedx/enterprise-integrated-channels',
-    'coaching': 'https://github.com/edx/platform-plugin-coaching',
     'completion': 'https://github.com/openedx/completion',
     'config_models': 'https://github.com/openedx/django-config-models',
     'consent': 'https://github.com/openedx/edx-enterprise',


### PR DESCRIPTION
# Description
Removed the mapping coaching from generate_code_owner_mappings.py based on the ownership spreadsheet changes. Ownership mappings will update correctly after this change.

