### PR TITLE
chore: Update package versions across requirements files for compatibility with Python 3.11

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -10,11 +10,11 @@ asgiref==3.11.1
     # via django
 billiard==4.2.4
     # via celery
-celery==5.6.2
+celery==5.6.3
     # via -r requirements/base.in
 cffi==2.0.0
     # via pynacl
-click==8.3.1
+click==8.3.3
     # via
     #   celery
     #   click-didyoumean
@@ -27,7 +27,7 @@ click-plugins==1.1.1.2
     # via celery
 click-repl==0.3.0
     # via celery
-django==5.2.12
+django==5.2.13
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/base.in
@@ -44,7 +44,7 @@ edx-django-utils==8.0.1
     # via -r requirements/base.in
 kombu==5.6.2
     # via celery
-packaging==26.0
+packaging==26.2
     # via kombu
 prompt-toolkit==3.0.52
     # via click-repl
@@ -62,7 +62,7 @@ sqlparse==0.5.5
     # via django
 stevedore==5.7.0
     # via edx-django-utils
-tzdata==2025.3
+tzdata==2026.2
     # via kombu
 tzlocal==5.3.1
     # via celery

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -4,22 +4,22 @@
 #
 #    make upgrade
 #
-cachetools==7.0.5
+cachetools==7.0.6
     # via tox
 colorama==0.4.6
     # via tox
 distlib==0.4.0
     # via virtualenv
-filelock==3.25.2
+filelock==3.29.0
     # via
     #   python-discovery
     #   tox
     #   virtualenv
-packaging==26.0
+packaging==26.2
     # via
     #   pyproject-api
     #   tox
-platformdirs==4.9.4
+platformdirs==4.9.6
     # via
     #   python-discovery
     #   tox
@@ -28,11 +28,13 @@ pluggy==1.6.0
     # via tox
 pyproject-api==1.10.0
     # via tox
-python-discovery==1.1.3
-    # via virtualenv
+python-discovery==1.2.2
+    # via
+    #   tox
+    #   virtualenv
 tomli-w==1.2.0
     # via tox
-tox==4.49.1
+tox==4.53.0
     # via -r requirements/ci.in
-virtualenv==21.2.0
+virtualenv==21.3.0
     # via tox

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -10,3 +10,14 @@
 
 # Common constraints for edx repos
 -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
+
+# The following packages dropped Python 3.11 support in their latest major version.
+# Pin them until this repo drops Python 3.11 support.
+# https://github.com/openedx/code-annotations/releases/tag/v3.0.0
+code-annotations<3.0.0
+# https://github.com/openedx/opaque-keys/releases/tag/4.0.0
+edx-opaque-keys<4.0.0
+# https://github.com/openedx/edx-toggles (dropped 3.11 in 6.0.0)
+edx-toggles<6.0.0
+# https://github.com/openedx/openedx-events/releases/tag/v11.2.0
+openedx-events<11.2.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -25,7 +25,7 @@ billiard==4.2.4
     # via
     #   -r requirements/quality.txt
     #   celery
-build==1.4.0
+build==1.4.4
     # via
     #   -r requirements/pip-tools.txt
     #   pip-tools
@@ -33,13 +33,13 @@ bytecode==0.17.0
     # via
     #   -r requirements/quality.txt
     #   ddtrace
-cachetools==7.0.5
+cachetools==7.0.6
     # via
     #   -r requirements/ci.txt
     #   tox
-celery==5.6.2
+celery==5.6.3
     # via -r requirements/quality.txt
-certifi==2026.2.25
+certifi==2026.4.22
     # via
     #   -r requirements/quality.txt
     #   datadog-api-client
@@ -49,13 +49,13 @@ cffi==2.0.0
     #   -r requirements/quality.txt
     #   cryptography
     #   pynacl
-chardet==7.1.0
+chardet==7.4.3
     # via diff-cover
-charset-normalizer==3.4.5
+charset-normalizer==3.4.7
     # via
     #   -r requirements/quality.txt
     #   requests
-click==8.3.1
+click==8.3.3
     # via
     #   -r requirements/pip-tools.txt
     #   -r requirements/quality.txt
@@ -86,25 +86,26 @@ click-repl==0.3.0
     #   celery
 code-annotations==2.3.2
     # via
+    #   -c requirements/constraints.txt
     #   -r requirements/quality.txt
     #   edx-lint
 colorama==0.4.6
     # via
     #   -r requirements/ci.txt
     #   tox
-coverage[toml]==7.13.4
+coverage[toml]==7.13.5
     # via
     #   -r requirements/quality.txt
     #   pytest-cov
-cryptography==46.0.5
+cryptography==47.0.0
     # via
     #   -r requirements/quality.txt
     #   secretstorage
-datadog-api-client==2.52.0
+datadog-api-client==2.54.0
     # via -r requirements/dev.in
 ddt==1.7.2
     # via -r requirements/quality.txt
-ddtrace==4.5.4
+ddtrace==4.7.1
     # via -r requirements/quality.txt
 diff-cover==10.2.0
     # via -r requirements/dev.in
@@ -116,7 +117,7 @@ distlib==0.4.0
     # via
     #   -r requirements/ci.txt
     #   virtualenv
-django==5.2.12
+django==5.2.13
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/quality.txt
@@ -140,13 +141,13 @@ edx-django-utils==8.0.1
     # via -r requirements/quality.txt
 edx-i18n-tools==2.0.0
     # via -r requirements/dev.in
-edx-lint==6.0.0
+edx-lint==6.1.0
     # via -r requirements/quality.txt
 envier==0.6.1
     # via
     #   -r requirements/quality.txt
     #   ddtrace
-filelock==3.25.2
+filelock==3.29.0
     # via
     #   -r requirements/ci.txt
     #   python-discovery
@@ -156,7 +157,7 @@ id==1.6.1
     # via
     #   -r requirements/quality.txt
     #   twine
-idna==3.11
+idna==3.13
     # via
     #   -r requirements/quality.txt
     #   requests
@@ -177,7 +178,7 @@ jaraco-classes==3.4.0
     # via
     #   -r requirements/quality.txt
     #   keyring
-jaraco-context==6.1.1
+jaraco-context==6.1.2
     # via
     #   -r requirements/quality.txt
     #   keyring
@@ -203,7 +204,7 @@ kombu==5.6.2
     # via
     #   -r requirements/quality.txt
     #   celery
-lxml[html-clean]==6.0.2
+lxml[html-clean]==6.1.0
     # via
     #   edx-i18n-tools
     #   lxml-html-clean
@@ -225,20 +226,20 @@ mdurl==0.1.2
     # via
     #   -r requirements/quality.txt
     #   markdown-it-py
-more-itertools==10.8.0
+more-itertools==11.0.2
     # via
     #   -r requirements/quality.txt
     #   jaraco-classes
     #   jaraco-functools
-nh3==0.3.3
+nh3==0.3.5
     # via
     #   -r requirements/quality.txt
     #   readme-renderer
-opentelemetry-api==1.40.0
+opentelemetry-api==1.41.1
     # via
     #   -r requirements/quality.txt
     #   ddtrace
-packaging==26.0
+packaging==26.2
     # via
     #   -r requirements/ci.txt
     #   -r requirements/pip-tools.txt
@@ -254,7 +255,7 @@ path==16.16.0
     # via edx-i18n-tools
 pip-tools==7.5.3
     # via -r requirements/pip-tools.txt
-platformdirs==4.9.4
+platformdirs==4.9.6
     # via
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
@@ -288,7 +289,7 @@ pycparser==3.0
     #   cffi
 pydocstyle==6.3.0
     # via -r requirements/quality.txt
-pygments==2.19.2
+pygments==2.20.0
     # via
     #   -r requirements/quality.txt
     #   diff-cover
@@ -328,26 +329,27 @@ pyproject-hooks==1.2.0
     #   -r requirements/pip-tools.txt
     #   build
     #   pip-tools
-pytest==9.0.2
+pytest==9.0.3
     # via
     #   -r requirements/quality.txt
     #   pytest-cov
     #   pytest-django
     #   pytest-randomly
-pytest-cov==7.0.0
+pytest-cov==7.1.0
     # via -r requirements/quality.txt
 pytest-django==4.12.0
     # via -r requirements/quality.txt
-pytest-randomly==4.0.1
+pytest-randomly==4.1.0
     # via -r requirements/quality.txt
 python-dateutil==2.9.0.post0
     # via
     #   -r requirements/quality.txt
     #   celery
     #   datadog-api-client
-python-discovery==1.1.3
+python-discovery==1.2.2
     # via
     #   -r requirements/ci.txt
+    #   tox
     #   virtualenv
 python-slugify==8.0.4
     # via
@@ -362,7 +364,7 @@ readme-renderer==44.0
     # via
     #   -r requirements/quality.txt
     #   twine
-requests==2.32.5
+requests==2.33.1
     # via
     #   -r requirements/quality.txt
     #   requests-toolbelt
@@ -375,7 +377,7 @@ rfc3986==2.0.0
     # via
     #   -r requirements/quality.txt
     #   twine
-rich==14.3.3
+rich==15.0.0
     # via
     #   -r requirements/quality.txt
     #   twine
@@ -412,8 +414,9 @@ tomli-w==1.2.0
 tomlkit==0.14.0
     # via
     #   -r requirements/quality.txt
+    #   edx-lint
     #   pylint
-tox==4.49.1
+tox==4.53.0
     # via -r requirements/ci.txt
 twine==6.2.0
     # via -r requirements/quality.txt
@@ -422,7 +425,7 @@ typing-extensions==4.15.0
     #   -r requirements/quality.txt
     #   datadog-api-client
     #   opentelemetry-api
-tzdata==2025.3
+tzdata==2026.2
     # via
     #   -r requirements/quality.txt
     #   kombu
@@ -443,7 +446,7 @@ vine==5.1.0
     #   amqp
     #   celery
     #   kombu
-virtualenv==21.2.0
+virtualenv==21.3.0
     # via
     #   -r requirements/ci.txt
     #   tox
@@ -451,7 +454,7 @@ wcwidth==0.6.0
     # via
     #   -r requirements/quality.txt
     #   prompt-toolkit
-wheel==0.46.3
+wheel==0.47.0
     # via
     #   -r requirements/pip-tools.txt
     #   pip-tools
@@ -459,13 +462,13 @@ wrapt==2.1.2
     # via
     #   -r requirements/quality.txt
     #   ddtrace
-zipp==3.23.0
+zipp==3.23.1
     # via
     #   -r requirements/quality.txt
     #   importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==26.0.1
+pip==26.1
     # via
     #   -r requirements/pip-tools.txt
     #   pip-tools

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -30,17 +30,17 @@ bytecode==0.17.0
     # via
     #   -r requirements/test.txt
     #   ddtrace
-celery==5.6.2
+celery==5.6.3
     # via -r requirements/test.txt
-certifi==2026.2.25
+certifi==2026.4.22
     # via requests
 cffi==2.0.0
     # via
     #   -r requirements/test.txt
     #   pynacl
-charset-normalizer==3.4.5
+charset-normalizer==3.4.7
     # via requests
-click==8.3.1
+click==8.3.3
     # via
     #   -r requirements/test.txt
     #   celery
@@ -62,16 +62,18 @@ click-repl==0.3.0
     #   -r requirements/test.txt
     #   celery
 code-annotations==2.3.2
-    # via -r requirements/test.txt
-coverage[toml]==7.13.4
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/test.txt
+coverage[toml]==7.13.5
     # via
     #   -r requirements/test.txt
     #   pytest-cov
 ddt==1.7.2
     # via -r requirements/test.txt
-ddtrace==4.5.4
+ddtrace==4.7.1
     # via -r requirements/test.txt
-django==5.2.12
+django==5.2.13
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/test.txt
@@ -101,7 +103,7 @@ envier==0.6.1
     # via
     #   -r requirements/test.txt
     #   ddtrace
-idna==3.11
+idna==3.13
     # via requests
 imagesize==2.0.0
     # via sphinx
@@ -126,13 +128,13 @@ markupsafe==3.0.3
     # via
     #   -r requirements/test.txt
     #   jinja2
-nh3==0.3.3
+nh3==0.3.5
     # via readme-renderer
-opentelemetry-api==1.40.0
+opentelemetry-api==1.41.1
     # via
     #   -r requirements/test.txt
     #   ddtrace
-packaging==26.0
+packaging==26.2
     # via
     #   -r requirements/test.txt
     #   kombu
@@ -157,7 +159,7 @@ pycparser==3.0
     #   cffi
 pydata-sphinx-theme==0.16.1
     # via sphinx-book-theme
-pygments==2.19.2
+pygments==2.20.0
     # via
     #   -r requirements/test.txt
     #   accessible-pygments
@@ -170,17 +172,17 @@ pynacl==1.6.2
     # via
     #   -r requirements/test.txt
     #   edx-django-utils
-pytest==9.0.2
+pytest==9.0.3
     # via
     #   -r requirements/test.txt
     #   pytest-cov
     #   pytest-django
     #   pytest-randomly
-pytest-cov==7.0.0
+pytest-cov==7.1.0
     # via -r requirements/test.txt
 pytest-django==4.12.0
     # via -r requirements/test.txt
-pytest-randomly==4.0.1
+pytest-randomly==4.1.0
     # via -r requirements/test.txt
 python-dateutil==2.9.0.post0
     # via
@@ -196,7 +198,7 @@ pyyaml==6.0.3
     #   code-annotations
 readme-renderer==44.0
     # via -r requirements/doc.in
-requests==2.32.5
+requests==2.33.1
     # via sphinx
 restructuredtext-lint==2.0.2
     # via doc8
@@ -249,7 +251,7 @@ typing-extensions==4.15.0
     #   beautifulsoup4
     #   opentelemetry-api
     #   pydata-sphinx-theme
-tzdata==2025.3
+tzdata==2026.2
     # via
     #   -r requirements/test.txt
     #   kombu
@@ -273,7 +275,7 @@ wrapt==2.1.2
     # via
     #   -r requirements/test.txt
     #   ddtrace
-zipp==3.23.0
+zipp==3.23.1
     # via
     #   -r requirements/test.txt
     #   importlib-metadata

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -4,11 +4,11 @@
 #
 #    make upgrade
 #
-build==1.4.0
+build==1.4.4
     # via pip-tools
-click==8.3.1
+click==8.3.3
     # via pip-tools
-packaging==26.0
+packaging==26.2
     # via
     #   build
     #   wheel
@@ -18,11 +18,11 @@ pyproject-hooks==1.2.0
     # via
     #   build
     #   pip-tools
-wheel==0.46.3
+wheel==0.47.0
     # via pip-tools
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==26.0.1
+pip==26.1
     # via pip-tools
 setuptools==82.0.1
     # via pip-tools

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -4,13 +4,13 @@
 #
 #    make upgrade
 #
-packaging==26.0
+packaging==26.2
     # via wheel
-wheel==0.46.3
+wheel==0.47.0
     # via -r requirements/pip.in
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==26.0.1
+pip==26.1
     # via -r requirements/pip.in
 setuptools==82.0.1
     # via -r requirements/pip.in

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -26,18 +26,18 @@ bytecode==0.17.0
     # via
     #   -r requirements/test.txt
     #   ddtrace
-celery==5.6.2
+celery==5.6.3
     # via -r requirements/test.txt
-certifi==2026.2.25
+certifi==2026.4.22
     # via requests
 cffi==2.0.0
     # via
     #   -r requirements/test.txt
     #   cryptography
     #   pynacl
-charset-normalizer==3.4.5
+charset-normalizer==3.4.7
     # via requests
-click==8.3.1
+click==8.3.3
     # via
     #   -r requirements/test.txt
     #   celery
@@ -64,21 +64,22 @@ click-repl==0.3.0
     #   celery
 code-annotations==2.3.2
     # via
+    #   -c requirements/constraints.txt
     #   -r requirements/test.txt
     #   edx-lint
-coverage[toml]==7.13.4
+coverage[toml]==7.13.5
     # via
     #   -r requirements/test.txt
     #   pytest-cov
-cryptography==46.0.5
+cryptography==47.0.0
     # via secretstorage
 ddt==1.7.2
     # via -r requirements/test.txt
-ddtrace==4.5.4
+ddtrace==4.7.1
     # via -r requirements/test.txt
 dill==0.4.1
     # via pylint
-django==5.2.12
+django==5.2.13
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/test.txt
@@ -97,7 +98,7 @@ docutils==0.22.4
     # via readme-renderer
 edx-django-utils==8.0.1
     # via -r requirements/test.txt
-edx-lint==6.0.0
+edx-lint==6.1.0
     # via -r requirements/quality.in
 envier==0.6.1
     # via
@@ -105,7 +106,7 @@ envier==0.6.1
     #   ddtrace
 id==1.6.1
     # via twine
-idna==3.11
+idna==3.13
     # via requests
 importlib-metadata==8.7.1
     # via
@@ -122,7 +123,7 @@ isort==8.0.1
     #   pylint
 jaraco-classes==3.4.0
     # via keyring
-jaraco-context==6.1.1
+jaraco-context==6.1.2
     # via keyring
 jaraco-functools==4.4.0
     # via keyring
@@ -150,23 +151,23 @@ mccabe==0.7.0
     # via pylint
 mdurl==0.1.2
     # via markdown-it-py
-more-itertools==10.8.0
+more-itertools==11.0.2
     # via
     #   jaraco-classes
     #   jaraco-functools
-nh3==0.3.3
+nh3==0.3.5
     # via readme-renderer
-opentelemetry-api==1.40.0
+opentelemetry-api==1.41.1
     # via
     #   -r requirements/test.txt
     #   ddtrace
-packaging==26.0
+packaging==26.2
     # via
     #   -r requirements/test.txt
     #   kombu
     #   pytest
     #   twine
-platformdirs==4.9.4
+platformdirs==4.9.6
     # via pylint
 pluggy==1.6.0
     # via
@@ -189,7 +190,7 @@ pycparser==3.0
     #   cffi
 pydocstyle==6.3.0
     # via -r requirements/quality.in
-pygments==2.19.2
+pygments==2.20.0
     # via
     #   -r requirements/test.txt
     #   pytest
@@ -213,17 +214,17 @@ pynacl==1.6.2
     # via
     #   -r requirements/test.txt
     #   edx-django-utils
-pytest==9.0.2
+pytest==9.0.3
     # via
     #   -r requirements/test.txt
     #   pytest-cov
     #   pytest-django
     #   pytest-randomly
-pytest-cov==7.0.0
+pytest-cov==7.1.0
     # via -r requirements/test.txt
 pytest-django==4.12.0
     # via -r requirements/test.txt
-pytest-randomly==4.0.1
+pytest-randomly==4.1.0
     # via -r requirements/test.txt
 python-dateutil==2.9.0.post0
     # via
@@ -239,7 +240,7 @@ pyyaml==6.0.3
     #   code-annotations
 readme-renderer==44.0
     # via twine
-requests==2.32.5
+requests==2.33.1
     # via
     #   requests-toolbelt
     #   twine
@@ -247,7 +248,7 @@ requests-toolbelt==1.0.0
     # via twine
 rfc3986==2.0.0
     # via twine
-rich==14.3.3
+rich==15.0.0
     # via twine
 secretstorage==3.5.0
     # via keyring
@@ -272,14 +273,16 @@ text-unidecode==1.3
     #   -r requirements/test.txt
     #   python-slugify
 tomlkit==0.14.0
-    # via pylint
+    # via
+    #   edx-lint
+    #   pylint
 twine==6.2.0
     # via -r requirements/quality.in
 typing-extensions==4.15.0
     # via
     #   -r requirements/test.txt
     #   opentelemetry-api
-tzdata==2025.3
+tzdata==2026.2
     # via
     #   -r requirements/test.txt
     #   kombu
@@ -306,7 +309,7 @@ wrapt==2.1.2
     # via
     #   -r requirements/test.txt
     #   ddtrace
-zipp==3.23.0
+zipp==3.23.1
     # via
     #   -r requirements/test.txt
     #   importlib-metadata

--- a/requirements/scripts.txt
+++ b/requirements/scripts.txt
@@ -8,17 +8,17 @@ amqp==5.3.1
     # via
     #   -r requirements/base.txt
     #   kombu
-anyio==4.12.1
+anyio==4.13.0
     # via httpx
 asgiref==3.11.1
     # via
     #   -r requirements/base.txt
     #   django
-attrs==25.4.0
+attrs==26.1.0
     # via
     #   confluent-kafka
     #   openedx-events
-authlib==1.6.9
+authlib==1.7.0
     # via confluent-kafka
 avro==1.12.1
     # via confluent-kafka
@@ -26,11 +26,11 @@ billiard==4.2.4
     # via
     #   -r requirements/base.txt
     #   celery
-cachetools==7.0.5
+cachetools==7.0.6
     # via confluent-kafka
-celery==5.6.2
+celery==5.6.3
     # via -r requirements/base.txt
-certifi==2026.2.25
+certifi==2026.4.22
     # via
     #   confluent-kafka
     #   httpcore
@@ -41,9 +41,9 @@ cffi==2.0.0
     #   -r requirements/base.txt
     #   cryptography
     #   pynacl
-charset-normalizer==3.4.5
+charset-normalizer==3.4.7
     # via requests
-click==8.3.1
+click==8.3.3
     # via
     #   -r requirements/base.txt
     #   celery
@@ -65,12 +65,16 @@ click-repl==0.3.0
     #   -r requirements/base.txt
     #   celery
 code-annotations==2.3.2
-    # via edx-toggles
-confluent-kafka[avro]==2.13.2
+    # via
+    #   -c requirements/constraints.txt
+    #   edx-toggles
+confluent-kafka[avro]==2.14.0
     # via -r requirements/scripts.in
-cryptography==46.0.5
-    # via authlib
-django==5.2.12
+cryptography==47.0.0
+    # via
+    #   authlib
+    #   joserfc
+django==5.2.13
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/base.txt
@@ -104,11 +108,14 @@ edx-event-bus-kafka==6.1.0
     # via -r requirements/scripts.in
 edx-opaque-keys[django]==3.1.0
     # via
+    #   -c requirements/constraints.txt
     #   edx-ccx-keys
     #   openedx-events
 edx-toggles==5.4.1
-    # via edx-event-bus-kafka
-fastavro==1.12.1
+    # via
+    #   -c requirements/constraints.txt
+    #   edx-event-bus-kafka
+fastavro==1.12.2
     # via
     #   confluent-kafka
     #   openedx-events
@@ -118,13 +125,15 @@ httpcore==1.0.9
     # via httpx
 httpx==0.28.1
     # via confluent-kafka
-idna==3.11
+idna==3.13
     # via
     #   anyio
     #   httpx
     #   requests
 jinja2==3.1.6
     # via code-annotations
+joserfc==1.6.4
+    # via authlib
 kombu==5.6.2
     # via
     #   -r requirements/base.txt
@@ -132,8 +141,10 @@ kombu==5.6.2
 markupsafe==3.0.3
     # via jinja2
 openedx-events==10.5.0
-    # via edx-event-bus-kafka
-packaging==26.0
+    # via
+    #   -c requirements/constraints.txt
+    #   edx-event-bus-kafka
+packaging==26.2
     # via
     #   -r requirements/base.txt
     #   kombu
@@ -149,7 +160,7 @@ pycparser==3.0
     # via
     #   -r requirements/base.txt
     #   cffi
-pymongo==4.16.0
+pymongo==4.17.0
     # via edx-opaque-keys
 pynacl==1.6.2
     # via
@@ -163,7 +174,7 @@ python-slugify==8.0.4
     # via code-annotations
 pyyaml==6.0.3
     # via code-annotations
-requests==2.32.5
+requests==2.33.1
     # via confluent-kafka
 six==1.17.0
     # via
@@ -186,7 +197,7 @@ typing-extensions==4.15.0
     # via
     #   anyio
     #   edx-opaque-keys
-tzdata==2025.3
+tzdata==2026.2
     # via
     #   -r requirements/base.txt
     #   kombu

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -18,13 +18,13 @@ billiard==4.2.4
     #   celery
 bytecode==0.17.0
     # via ddtrace
-celery==5.6.2
+celery==5.6.3
     # via -r requirements/base.txt
 cffi==2.0.0
     # via
     #   -r requirements/base.txt
     #   pynacl
-click==8.3.1
+click==8.3.3
     # via
     #   -r requirements/base.txt
     #   celery
@@ -46,12 +46,14 @@ click-repl==0.3.0
     #   -r requirements/base.txt
     #   celery
 code-annotations==2.3.2
-    # via -r requirements/test.in
-coverage[toml]==7.13.4
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/test.in
+coverage[toml]==7.13.5
     # via pytest-cov
 ddt==1.7.2
     # via -r requirements/test.in
-ddtrace==4.5.4
+ddtrace==4.7.1
     # via -r requirements/test.in
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
@@ -83,9 +85,9 @@ kombu==5.6.2
     #   celery
 markupsafe==3.0.3
     # via jinja2
-opentelemetry-api==1.40.0
+opentelemetry-api==1.41.1
     # via ddtrace
-packaging==26.0
+packaging==26.2
     # via
     #   -r requirements/base.txt
     #   kombu
@@ -106,22 +108,22 @@ pycparser==3.0
     # via
     #   -r requirements/base.txt
     #   cffi
-pygments==2.19.2
+pygments==2.20.0
     # via pytest
 pynacl==1.6.2
     # via
     #   -r requirements/base.txt
     #   edx-django-utils
-pytest==9.0.2
+pytest==9.0.3
     # via
     #   pytest-cov
     #   pytest-django
     #   pytest-randomly
-pytest-cov==7.0.0
+pytest-cov==7.1.0
     # via -r requirements/test.in
 pytest-django==4.12.0
     # via -r requirements/test.in
-pytest-randomly==4.0.1
+pytest-randomly==4.1.0
     # via -r requirements/test.in
 python-dateutil==2.9.0.post0
     # via
@@ -148,7 +150,7 @@ text-unidecode==1.3
     # via python-slugify
 typing-extensions==4.15.0
     # via opentelemetry-api
-tzdata==2025.3
+tzdata==2026.2
     # via
     #   -r requirements/base.txt
     #   kombu
@@ -168,7 +170,7 @@ wcwidth==0.6.0
     #   prompt-toolkit
 wrapt==2.1.2
     # via ddtrace
-zipp==3.23.0
+zipp==3.23.1
     # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:


### PR DESCRIPTION
### Description:

Updates the repo’s pinned Python dependencies (compiled via pip-tools) to newer versions while preserving Python 3.11 compatibility by introducing explicit constraints for packages that have dropped 3.11 support in newer major releases.

### Changes:

- Bump pinned versions across environment-specific requirements files (`base/test/dev/ci/doc/quality/scripts`, plus `pip/pip-tools`).
- Add/extend requirements/constraints.txt to cap select Open edX packages below major versions that drop Python 3.11 support.
- Regenerate requirements metadata/comments to reflect constraints provenance (e.g., # via -c requirements/constraints.txt) where applicable.