### PR TITLE
feat: Add certificate retirement API for individual users and implement related helper functions

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,15 @@ Change Log
 Unreleased
 **********
 
+[7.5.0] - 2026-05-11
+********************
+Added
+=====
+* Added ``RetireCertificatesS3ForUserView`` (``POST /api/certificates/v1/retire_certs_s3_for_user``)
+  for per-user certificate retirement as a step in ``retire_one_learner.py``. Returns HTTP 207
+  on partial failure.
+* Added unit tests for ``edx_arch_experiments.certificates.views``.
+
 [7.4.0] - 2026-04-28
 ********************
 Added

--- a/edx_arch_experiments/__init__.py
+++ b/edx_arch_experiments/__init__.py
@@ -2,4 +2,4 @@
 A plugin to include applications under development by the architecture team at 2U.
 """
 
-__version__ = '7.4.0'
+__version__ = '7.5.0'

--- a/edx_arch_experiments/certificates/tests/test_views.py
+++ b/edx_arch_experiments/certificates/tests/test_views.py
@@ -82,6 +82,7 @@ def _restore_sys_modules():
         else:
             sys.modules[key] = original
 
+
 # Patch target strings — centralised so a rename only needs changing here.
 _PATCH_FETCH_USER = 'edx_arch_experiments.certificates.views._fetch_certs_to_delete_for_user'
 _PATCH_FETCH_ALL = 'edx_arch_experiments.certificates.views._fetch_certs_to_delete'
@@ -240,9 +241,9 @@ class TestRetireCertificatesS3ForUserView(_BaseViewTestCase):
         return views.RetireCertificatesS3ForUserView.as_view()(request)
 
     @ddt.data(
-        {},                          # username key absent entirely
-        {'username': '   '},         # username present but blank after strip
-        {'username': 'active_user'}, # not a retired username
+        {},                            # username key absent entirely
+        {'username': '   '},           # username present but blank after strip
+        {'username': 'active_user'},   # not a retired username
     )
     def test_bad_username_returns_400(self, body):
         response = self._post(body)

--- a/edx_arch_experiments/certificates/tests/test_views.py
+++ b/edx_arch_experiments/certificates/tests/test_views.py
@@ -4,11 +4,14 @@ Unit tests for edx_arch_experiments.certificates.views.
 All LMS-internal models and permissions are mocked at the module level so
 these tests run standalone without an LMS Django environment.
 """
+# Tests intentionally access private module helpers (leading-underscore functions)
+# and constants from the views module under test.
+# pylint: disable=protected-access
 
 import json
 import sys
 from types import ModuleType
-from unittest.mock import MagicMock, Mock, patch
+from unittest.mock import MagicMock, patch
 
 import ddt
 import pytest
@@ -57,7 +60,10 @@ _PATCH_S3         = 'edx_arch_experiments.certificates.views.S3Client'
 # Helpers
 # ---------------------------------------------------------------------------
 
-def _make_cert(cert_id, user_id, download_url, verify_uuid='abc', download_uuid='def', course_id='course-v1:edX+Test+2026'):
+def _make_cert(  # pylint: disable=too-many-positional-arguments
+    cert_id, user_id, download_url,
+    verify_uuid='abc', download_uuid='def', course_id='course-v1:edX+Test+2026',
+):
     """Return a MagicMock mimicking a GeneratedCertificate instance."""
     cert = MagicMock()
     cert.id = cert_id
@@ -171,22 +177,14 @@ class _BaseViewTestCase(TestCase):
         super().setUp()
         self.factory = RequestFactory()
         # Strip permissions from both view classes for the duration of each test.
-        from edx_arch_experiments.certificates.views import (
-            RetireCertificatesS3ForUserView,
-            RetireCertificatesS3View,
-        )
         self._saved = {
-            RetireCertificatesS3ForUserView: RetireCertificatesS3ForUserView.permission_classes,
-            RetireCertificatesS3View: RetireCertificatesS3View.permission_classes,
+            views.RetireCertificatesS3ForUserView: views.RetireCertificatesS3ForUserView.permission_classes,
+            views.RetireCertificatesS3View: views.RetireCertificatesS3View.permission_classes,
         }
-        RetireCertificatesS3ForUserView.permission_classes = []
-        RetireCertificatesS3View.permission_classes = []
+        views.RetireCertificatesS3ForUserView.permission_classes = []
+        views.RetireCertificatesS3View.permission_classes = []
 
     def tearDown(self):
-        from edx_arch_experiments.certificates.views import (
-            RetireCertificatesS3ForUserView,
-            RetireCertificatesS3View,
-        )
         for cls, original in self._saved.items():
             cls.permission_classes = original
         super().tearDown()
@@ -201,13 +199,13 @@ class TestRetireCertificatesS3ForUserView(_BaseViewTestCase):
     """Tests for POST /api/certificates/v1/retire_certs_s3_for_user."""
 
     def _post(self, data=None):
-        from edx_arch_experiments.certificates.views import RetireCertificatesS3ForUserView
+        """POST to retire_certs_s3_for_user and return the DRF Response."""
         request = self.factory.post(
             '/api/certificates/v1/retire_certs_s3_for_user',
             data=json.dumps(data or {}),
             content_type='application/json',
         )
-        return RetireCertificatesS3ForUserView.as_view()(request)
+        return views.RetireCertificatesS3ForUserView.as_view()(request)
 
     @ddt.data(
         {},                          # username key absent entirely
@@ -278,12 +276,12 @@ class TestRetireCertificatesS3View(_BaseViewTestCase):
     """Tests for POST /api/certificates/v1/retire_certs_s3."""
 
     def _post(self, query_string=''):
-        from edx_arch_experiments.certificates.views import RetireCertificatesS3View
+        """POST to retire_certs_s3 (with optional query string) and return the DRF Response."""
         request = self.factory.post(
             f'/api/certificates/v1/retire_certs_s3{query_string}',
             content_type='application/json',
         )
-        return RetireCertificatesS3View.as_view()(request)
+        return views.RetireCertificatesS3View.as_view()(request)
 
     @patch(_PATCH_FETCH_ALL)
     def test_no_certs_returns_200(self, mock_fetch):
@@ -356,7 +354,8 @@ class TestFetchCertsToDeleteForUser(TestCase):
 
     def test_calls_filter_with_correct_username(self):
         mock_qs = MagicMock()
-        views.GeneratedCertificate.objects.filter.return_value.select_related.return_value.order_by.return_value = mock_qs
+        filter_mock = views.GeneratedCertificate.objects.filter.return_value
+        filter_mock.select_related.return_value.order_by.return_value = mock_qs
         result = views._fetch_certs_to_delete_for_user('retired__user_abc')
         views.GeneratedCertificate.objects.filter.assert_called_once_with(
             user__username='retired__user_abc',

--- a/edx_arch_experiments/certificates/tests/test_views.py
+++ b/edx_arch_experiments/certificates/tests/test_views.py
@@ -1,0 +1,366 @@
+"""
+Unit tests for edx_arch_experiments.certificates.views.
+
+All LMS-internal models and permissions are mocked at the module level so
+these tests run standalone without an LMS Django environment.
+"""
+
+import json
+import sys
+from types import ModuleType
+from unittest.mock import MagicMock, Mock, patch
+
+import ddt
+import pytest
+from botocore.exceptions import ClientError
+from django.test import RequestFactory, TestCase
+from rest_framework import status
+
+# ---------------------------------------------------------------------------
+# Stub out LMS modules that views.py imports at module load time.
+# These must be installed before importing the views module.
+# ---------------------------------------------------------------------------
+
+def _make_module(name):
+    mod = ModuleType(name)
+    sys.modules[name] = mod
+    return mod
+
+
+_certs_data = _make_module('lms.djangoapps.certificates.data')
+_certs_data.CertificateStatuses = MagicMock(downloadable='downloadable', deleted='deleted')
+
+_certs_models = _make_module('lms.djangoapps.certificates.models')
+_certs_models.GeneratedCertificate = MagicMock()
+
+_user_api = _make_module('openedx.core.djangoapps.user_api')
+_user_api_accounts = _make_module('openedx.core.djangoapps.user_api.accounts')
+_user_api_perms = _make_module('openedx.core.djangoapps.user_api.accounts.permissions')
+_user_api_perms.CanRetireUser = MagicMock()
+
+# Ensure parent packages exist in sys.modules
+for pkg in ('lms', 'lms.djangoapps', 'lms.djangoapps.certificates',
+            'openedx', 'openedx.core', 'openedx.core.djangoapps'):
+    if pkg not in sys.modules:
+        sys.modules[pkg] = ModuleType(pkg)
+
+# Now import the module under test
+from edx_arch_experiments.certificates import views  # noqa: E402  pylint: disable=wrong-import-position
+
+# Patch target strings — centralised so a rename only needs changing here.
+_PATCH_FETCH_USER = 'edx_arch_experiments.certificates.views._fetch_certs_to_delete_for_user'
+_PATCH_FETCH_ALL  = 'edx_arch_experiments.certificates.views._fetch_certs_to_delete'
+_PATCH_S3         = 'edx_arch_experiments.certificates.views.S3Client'
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_cert(cert_id, user_id, download_url, verify_uuid='abc', download_uuid='def', course_id='course-v1:edX+Test+2026'):
+    """Return a MagicMock mimicking a GeneratedCertificate instance."""
+    cert = MagicMock()
+    cert.id = cert_id
+    cert.user_id = user_id
+    cert.download_url = download_url
+    cert.verify_uuid = verify_uuid
+    cert.download_uuid = download_uuid
+    cert.course_id = course_id
+    cert.status = 'downloadable'
+    return cert
+
+
+_VALID_URL = 'https://s3.amazonaws.com/verify.edx.org/cert-123.pdf'
+_VALID_URL2 = 'https://s3.amazonaws.com/verify.edx.org/cert-456.pdf'
+
+
+# ---------------------------------------------------------------------------
+# Tests for _s3_keys_from_cert
+# ---------------------------------------------------------------------------
+
+@ddt.ddt
+class TestS3KeysFromCert(TestCase):
+    """Tests for the _s3_keys_from_cert helper."""
+
+    def test_valid_path_style_url(self):
+        cert = _make_cert(1, 10, _VALID_URL, verify_uuid='v1', download_uuid='d1')
+        bucket, verify_prefix, download_key = views._s3_keys_from_cert(cert)
+        assert bucket == 'verify.edx.org'
+        assert verify_prefix == 'cert/v1/'
+        assert download_key == 'downloads/d1/Certificate.pdf'
+
+    @ddt.data(
+        ('https://cdn.example.com/bucket/key', 'Unexpected S3 host'),
+        (f'https://{views._EXPECTED_S3_HOST}/', 'Cannot derive S3 bucket'),
+    )
+    @ddt.unpack
+    def test_bad_url_raises_value_error(self, url, expected_msg):
+        cert = _make_cert(1, 10, url)
+        with pytest.raises(ValueError, match=expected_msg):
+            views._s3_keys_from_cert(cert)
+
+
+# ---------------------------------------------------------------------------
+# Tests for _retire_single_cert
+# ---------------------------------------------------------------------------
+
+@ddt.ddt
+class TestRetireSingleCert(TestCase):
+    """Tests for the shared _retire_single_cert helper."""
+
+    def _make_s3(self, side_effect=None):
+        s3 = MagicMock()
+        s3.delete_objects_by_prefix = MagicMock(side_effect=side_effect)
+        s3.delete_object = MagicMock()
+        return s3
+
+    def test_success(self):
+        cert = _make_cert(1, 10, _VALID_URL, verify_uuid='v1', download_uuid='d1')
+        s3 = self._make_s3()
+        result = views._retire_single_cert(s3, cert, 'test')
+        assert result is True
+        s3.delete_objects_by_prefix.assert_called_once_with('verify.edx.org', 'cert/v1/')
+        s3.delete_object.assert_called_once_with('verify.edx.org', 'downloads/d1/Certificate.pdf')
+        cert.save.assert_called_once()
+
+    def test_db_fields_updated_on_success(self):
+        cert = _make_cert(1, 10, _VALID_URL, verify_uuid='v1', download_uuid='d1')
+        s3 = self._make_s3()
+        views._retire_single_cert(s3, cert, 'test')
+        assert cert.status == views.CertificateStatuses.deleted
+        assert cert.download_url == ''
+        assert cert.download_uuid == ''
+
+    def _client_error(self):
+        return ClientError({'Error': {'Code': 'AccessDenied', 'Message': 'denied'}}, 'DeleteObjects')
+
+    @ddt.data(
+        # (url, s3_side_effect)  — all cases must return False and skip save
+        ('https://cdn.example.com/bad', None),           # bad URL: ValueError before S3 call
+        (_VALID_URL, 'client_error'),                    # S3 ClientError
+        (_VALID_URL, RuntimeError('boom')),              # unexpected exception
+    )
+    @ddt.unpack
+    def test_failure_returns_false_and_skips_save(self, url, s3_side_effect):
+        if s3_side_effect == 'client_error':
+            s3_side_effect = self._client_error()
+        cert = _make_cert(1, 10, url, verify_uuid='v1', download_uuid='d1')
+        s3 = self._make_s3(side_effect=s3_side_effect)
+        result = views._retire_single_cert(s3, cert, 'test')
+        assert result is False
+        cert.save.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Base class for view tests — handles auth bypass
+# ---------------------------------------------------------------------------
+
+class _BaseViewTestCase(TestCase):
+    """
+    Bypasses DRF permission checking so view logic can be tested in isolation.
+
+    DRF's ``Request`` wrapper re-derives ``request.user`` via its own
+    authentication pipeline, so setting ``request.user = Mock(…)`` on a plain
+    Django request has no effect.  Setting ``permission_classes = []`` directly
+    on each view class before the test is the most reliable bypass — DRF's
+    ``get_permissions()`` simply returns an empty list and ``check_permissions``
+    performs no checks.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.factory = RequestFactory()
+        # Strip permissions from both view classes for the duration of each test.
+        from edx_arch_experiments.certificates.views import (
+            RetireCertificatesS3ForUserView,
+            RetireCertificatesS3View,
+        )
+        self._saved = {
+            RetireCertificatesS3ForUserView: RetireCertificatesS3ForUserView.permission_classes,
+            RetireCertificatesS3View: RetireCertificatesS3View.permission_classes,
+        }
+        RetireCertificatesS3ForUserView.permission_classes = []
+        RetireCertificatesS3View.permission_classes = []
+
+    def tearDown(self):
+        from edx_arch_experiments.certificates.views import (
+            RetireCertificatesS3ForUserView,
+            RetireCertificatesS3View,
+        )
+        for cls, original in self._saved.items():
+            cls.permission_classes = original
+        super().tearDown()
+
+
+# ---------------------------------------------------------------------------
+# Tests for RetireCertificatesS3ForUserView
+# ---------------------------------------------------------------------------
+
+@ddt.ddt
+class TestRetireCertificatesS3ForUserView(_BaseViewTestCase):
+    """Tests for POST /api/certificates/v1/retire_certs_s3_for_user."""
+
+    def _post(self, data=None):
+        from edx_arch_experiments.certificates.views import RetireCertificatesS3ForUserView
+        request = self.factory.post(
+            '/api/certificates/v1/retire_certs_s3_for_user',
+            data=json.dumps(data or {}),
+            content_type='application/json',
+        )
+        return RetireCertificatesS3ForUserView.as_view()(request)
+
+    @ddt.data(
+        {},                          # username key absent entirely
+        {'username': '   '},         # username present but blank after strip
+    )
+    def test_bad_username_returns_400(self, body):
+        response = self._post(body)
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert 'username' in response.data['error']
+
+    @patch(_PATCH_FETCH_USER, return_value=[])
+    def test_no_certs_returns_200(self, _mock_fetch):
+        response = self._post({'username': 'retired__user_abc'})
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data == {'username': 'retired__user_abc', 'processed': 0, 'failed': []}
+
+    @patch(_PATCH_S3)
+    @patch(_PATCH_FETCH_USER)
+    def test_all_certs_succeed_returns_200(self, mock_fetch, _MockS3):
+        mock_fetch.return_value = [
+            _make_cert(1, 10, _VALID_URL,  verify_uuid='v1', download_uuid='d1'),
+            _make_cert(2, 10, _VALID_URL2, verify_uuid='v2', download_uuid='d2'),
+        ]
+        response = self._post({'username': 'retired__user_abc'})
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data['processed'] == 2
+        assert response.data['failed'] == []
+
+    @patch(_PATCH_S3)
+    @patch(_PATCH_FETCH_USER)
+    def test_partial_failure_returns_207(self, mock_fetch, MockS3):
+        mock_fetch.return_value = [
+            _make_cert(1, 10, _VALID_URL,  verify_uuid='v1', download_uuid='d1'),
+            _make_cert(2, 10, _VALID_URL2, verify_uuid='v2', download_uuid='d2'),
+        ]
+        MockS3.return_value.delete_objects_by_prefix.side_effect = [
+            None,
+            ClientError({'Error': {'Code': 'AccessDenied', 'Message': 'denied'}}, 'DeleteObjects'),
+        ]
+        response = self._post({'username': 'retired__user_abc'})
+        assert response.status_code == status.HTTP_207_MULTI_STATUS
+        assert response.data['processed'] == 1
+        assert response.data['failed'] == [2]
+
+    @patch(_PATCH_FETCH_USER, return_value=[_make_cert(1, 10, 'https://cdn.example.com/bad')])
+    def test_all_certs_fail_returns_207(self, _mock_fetch):
+        response = self._post({'username': 'retired__user_abc'})
+        assert response.status_code == status.HTTP_207_MULTI_STATUS
+        assert response.data['processed'] == 0
+        assert response.data['failed'] == [1]
+
+    @patch(_PATCH_FETCH_USER, side_effect=RuntimeError('db error'))
+    def test_db_query_error_returns_500(self, _mock_fetch):
+        response = self._post({'username': 'retired__user_abc'})
+        assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
+
+    @patch(_PATCH_FETCH_USER, return_value=[])
+    def test_username_is_stripped(self, mock_fetch):
+        self._post({'username': '  retired__user_abc  '})
+        mock_fetch.assert_called_once_with('retired__user_abc')
+
+
+# ---------------------------------------------------------------------------
+# Tests for RetireCertificatesS3View (batch)
+# ---------------------------------------------------------------------------
+
+class TestRetireCertificatesS3View(_BaseViewTestCase):
+    """Tests for POST /api/certificates/v1/retire_certs_s3."""
+
+    def _post(self, query_string=''):
+        from edx_arch_experiments.certificates.views import RetireCertificatesS3View
+        request = self.factory.post(
+            f'/api/certificates/v1/retire_certs_s3{query_string}',
+            content_type='application/json',
+        )
+        return RetireCertificatesS3View.as_view()(request)
+
+    @patch(_PATCH_FETCH_ALL)
+    def test_no_certs_returns_200(self, mock_fetch):
+        mock_fetch.return_value.iterator.return_value = iter([])
+        response = self._post()
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data == {'processed': 0, 'failed': []}
+
+    @patch(_PATCH_S3)
+    @patch(_PATCH_FETCH_ALL)
+    def test_all_certs_succeed_returns_200(self, mock_fetch, _MockS3):
+        mock_fetch.return_value.iterator.return_value = iter([
+            _make_cert(1, 10, _VALID_URL,  verify_uuid='v1', download_uuid='d1'),
+            _make_cert(2, 20, _VALID_URL2, verify_uuid='v2', download_uuid='d2'),
+        ])
+        response = self._post()
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data['processed'] == 2
+        assert response.data['failed'] == []
+
+    @patch(_PATCH_S3)
+    @patch(_PATCH_FETCH_ALL)
+    def test_partial_failure_returns_207(self, mock_fetch, MockS3):
+        mock_fetch.return_value.iterator.return_value = iter([
+            _make_cert(1, 10, _VALID_URL,  verify_uuid='v1', download_uuid='d1'),
+            _make_cert(2, 20, _VALID_URL2, verify_uuid='v2', download_uuid='d2'),
+        ])
+        MockS3.return_value.delete_objects_by_prefix.side_effect = [
+            None,
+            ClientError({'Error': {'Code': 'AccessDenied', 'Message': 'denied'}}, 'DeleteObjects'),
+        ]
+        response = self._post()
+        assert response.status_code == status.HTTP_207_MULTI_STATUS
+        assert response.data['processed'] == 1
+        assert response.data['failed'] == [2]
+
+    @patch(_PATCH_S3)
+    @patch(_PATCH_FETCH_ALL)
+    def test_dry_run_makes_no_changes(self, mock_fetch, MockS3):
+        cert = _make_cert(1, 10, _VALID_URL, verify_uuid='v1', download_uuid='d1')
+        mock_fetch.return_value.iterator.return_value = iter([cert])
+        response = self._post('?dry_run=true')
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data['processed'] == 1
+        MockS3.return_value.delete_objects_by_prefix.assert_not_called()
+        MockS3.return_value.delete_object.assert_not_called()
+        cert.save.assert_not_called()
+
+    @patch(_PATCH_FETCH_ALL, side_effect=RuntimeError('db error'))
+    def test_db_query_error_returns_500(self, _mock_fetch):
+        response = self._post()
+        assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
+
+    @patch(_PATCH_S3)
+    @patch(_PATCH_FETCH_ALL)
+    def test_dry_run_false_by_default(self, mock_fetch, MockS3):
+        """dry_run query param defaults to false — changes ARE made."""
+        cert = _make_cert(1, 10, _VALID_URL, verify_uuid='v1', download_uuid='d1')
+        mock_fetch.return_value.iterator.return_value = iter([cert])
+        self._post()
+        MockS3.return_value.delete_objects_by_prefix.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Tests for _fetch_certs_to_delete_for_user
+# ---------------------------------------------------------------------------
+
+class TestFetchCertsToDeleteForUser(TestCase):
+    """Tests for the per-user queryset helper."""
+
+    def test_calls_filter_with_correct_username(self):
+        mock_qs = MagicMock()
+        views.GeneratedCertificate.objects.filter.return_value.select_related.return_value.order_by.return_value = mock_qs
+        result = views._fetch_certs_to_delete_for_user('retired__user_abc')
+        views.GeneratedCertificate.objects.filter.assert_called_once_with(
+            user__username='retired__user_abc',
+            download_url__icontains='https://',
+            status=views.CertificateStatuses.downloadable,
+        )
+        assert result == mock_qs

--- a/edx_arch_experiments/certificates/tests/test_views.py
+++ b/edx_arch_experiments/certificates/tests/test_views.py
@@ -21,8 +21,29 @@ from rest_framework import status
 
 # ---------------------------------------------------------------------------
 # Stub out LMS modules that views.py imports at module load time.
-# These must be installed before importing the views module.
+# These must be installed before importing the views module, so the stubs are
+# created at module scope.  We snapshot sys.modules first and restore it in a
+# module-scoped autouse fixture so the fake entries don't leak into unrelated
+# tests running in the same pytest session.
 # ---------------------------------------------------------------------------
+
+_STUB_KEYS = [
+    'lms',
+    'lms.djangoapps',
+    'lms.djangoapps.certificates',
+    'lms.djangoapps.certificates.data',
+    'lms.djangoapps.certificates.models',
+    'openedx',
+    'openedx.core',
+    'openedx.core.djangoapps',
+    'openedx.core.djangoapps.user_api',
+    'openedx.core.djangoapps.user_api.accounts',
+    'openedx.core.djangoapps.user_api.accounts.permissions',
+]
+
+# Snapshot whatever was already registered before we install the stubs.
+_sys_modules_snapshot = {k: sys.modules.get(k) for k in _STUB_KEYS}
+
 
 def _make_module(name):
     mod = ModuleType(name)
@@ -42,18 +63,29 @@ _user_api_perms = _make_module('openedx.core.djangoapps.user_api.accounts.permis
 _user_api_perms.CanRetireUser = MagicMock()
 
 # Ensure parent packages exist in sys.modules
-for pkg in ('lms', 'lms.djangoapps', 'lms.djangoapps.certificates',
-            'openedx', 'openedx.core', 'openedx.core.djangoapps'):
-    if pkg not in sys.modules:
-        sys.modules[pkg] = ModuleType(pkg)
+for _pkg in ('lms', 'lms.djangoapps', 'lms.djangoapps.certificates',
+             'openedx', 'openedx.core', 'openedx.core.djangoapps'):
+    if _pkg not in sys.modules:
+        sys.modules[_pkg] = ModuleType(_pkg)
 
 # Now import the module under test
 from edx_arch_experiments.certificates import views  # noqa: E402  pylint: disable=wrong-import-position
 
+
+@pytest.fixture(scope='module', autouse=True)
+def _restore_sys_modules():
+    """Remove stub modules from sys.modules after all tests in this file run."""
+    yield
+    for key, original in _sys_modules_snapshot.items():
+        if original is None:
+            sys.modules.pop(key, None)
+        else:
+            sys.modules[key] = original
+
 # Patch target strings — centralised so a rename only needs changing here.
 _PATCH_FETCH_USER = 'edx_arch_experiments.certificates.views._fetch_certs_to_delete_for_user'
-_PATCH_FETCH_ALL  = 'edx_arch_experiments.certificates.views._fetch_certs_to_delete'
-_PATCH_S3         = 'edx_arch_experiments.certificates.views.S3Client'
+_PATCH_FETCH_ALL = 'edx_arch_experiments.certificates.views._fetch_certs_to_delete'
+_PATCH_S3 = 'edx_arch_experiments.certificates.views.S3Client'
 
 
 # ---------------------------------------------------------------------------
@@ -210,6 +242,7 @@ class TestRetireCertificatesS3ForUserView(_BaseViewTestCase):
     @ddt.data(
         {},                          # username key absent entirely
         {'username': '   '},         # username present but blank after strip
+        {'username': 'active_user'}, # not a retired username
     )
     def test_bad_username_returns_400(self, body):
         response = self._post(body)
@@ -326,8 +359,20 @@ class TestRetireCertificatesS3View(_BaseViewTestCase):
         response = self._post('?dry_run=true')
         assert response.status_code == status.HTTP_200_OK
         assert response.data['processed'] == 1
+        assert response.data['failed'] == []
         MockS3.return_value.delete_objects_by_prefix.assert_not_called()
         MockS3.return_value.delete_object.assert_not_called()
+        cert.save.assert_not_called()
+
+    @patch(_PATCH_FETCH_ALL)
+    def test_dry_run_bad_url_counts_as_failure(self, mock_fetch):
+        """Dry-run calls _s3_keys_from_cert; invalid URL → 207, no S3 calls."""
+        cert = _make_cert(1, 10, 'https://cdn.example.com/bad')
+        mock_fetch.return_value.iterator.return_value = iter([cert])
+        response = self._post('?dry_run=true')
+        assert response.status_code == status.HTTP_207_MULTI_STATUS
+        assert response.data['processed'] == 0
+        assert response.data['failed'] == [1]
         cert.save.assert_not_called()
 
     @patch(_PATCH_FETCH_ALL, side_effect=RuntimeError('db error'))
@@ -359,6 +404,7 @@ class TestFetchCertsToDeleteForUser(TestCase):
         result = views._fetch_certs_to_delete_for_user('retired__user_abc')
         views.GeneratedCertificate.objects.filter.assert_called_once_with(
             user__username='retired__user_abc',
+            user__username__startswith=views._RETIRED_USERNAME_PREFIX,
             download_url__icontains='https://',
             status=views.CertificateStatuses.downloadable,
         )

--- a/edx_arch_experiments/certificates/urls.py
+++ b/edx_arch_experiments/certificates/urls.py
@@ -4,8 +4,9 @@ Certificate retirement API URLs.
 
 from django.urls import path
 
-from edx_arch_experiments.certificates.views import RetireCertificatesS3View
+from edx_arch_experiments.certificates.views import RetireCertificatesS3ForUserView, RetireCertificatesS3View
 
 urlpatterns = [
     path('retire_certs_s3', RetireCertificatesS3View.as_view(), name='retire_certs_s3'),
+    path('retire_certs_s3_for_user', RetireCertificatesS3ForUserView.as_view(), name='retire_certs_s3_for_user'),
 ]

--- a/edx_arch_experiments/certificates/views.py
+++ b/edx_arch_experiments/certificates/views.py
@@ -71,6 +71,18 @@ class S3Client:
             self._delete_objects_batch(bucket, batch)
 
 
+def _fetch_certs_to_delete_for_user(username):
+    """
+    Returns a queryset of GeneratedCertificate records for the given retired
+    user that still have a downloadable PDF certificate URL.
+    """
+    return GeneratedCertificate.objects.filter(
+        user__username=username,
+        download_url__icontains='https://',
+        status=CertificateStatuses.downloadable,
+    ).select_related('user').order_by('course_id')
+
+
 def _fetch_certs_to_delete():
     """
     Returns a queryset of GeneratedCertificate records belonging to retired
@@ -111,6 +123,122 @@ def _s3_keys_from_cert(cert):
     verify_prefix = f'cert/{cert.verify_uuid}/'
     download_key = f'downloads/{cert.download_uuid}/Certificate.pdf'
     return bucket, verify_prefix, download_key
+
+
+def _retire_single_cert(s3, cert, log_prefix):
+    """
+    Delete S3 objects for a single certificate and mark it as deleted in the DB.
+
+    Returns True on success, False on failure (already logged).
+    The caller is responsible for appending cert.id to failed_ids on False.
+    """
+    try:
+        bucket, verify_prefix, download_key = _s3_keys_from_cert(cert)
+    except ValueError as exc:
+        log.error(
+            '%s: skipping cert %s (user %s) — bad download_url: %s',
+            log_prefix, cert.id, cert.user_id, exc,
+        )
+        return False
+
+    try:
+        s3.delete_objects_by_prefix(bucket, verify_prefix)
+        s3.delete_object(bucket, download_key)
+
+        cert.status = CertificateStatuses.deleted
+        cert.download_url = ''
+        cert.download_uuid = ''
+        cert.save(update_fields=['status', 'download_url', 'download_uuid'])
+
+        log.info(
+            '%s: cert %s (user %s) deleted from S3 and marked deleted in DB',
+            log_prefix, cert.id, cert.user_id,
+        )
+        return True
+
+    except ClientError as exc:
+        log.error('%s: S3 error for cert %s (user %s): %s', log_prefix, cert.id, cert.user_id, exc)
+        return False
+    except Exception as exc:  # pylint: disable=broad-except
+        log.exception('%s: unexpected error for cert %s (user %s): %s', log_prefix, cert.id, cert.user_id, exc)
+        return False
+
+
+class RetireCertificatesS3ForUserView(APIView):
+    """
+    POST /api/certificates/v1/retire_certs_s3_for_user
+
+    Finds all GeneratedCertificate records for a single retired user that still
+    have a downloadable PDF URL, deletes the corresponding S3 objects, then
+    marks the DB record as deleted.
+
+    This endpoint is designed to be called per-user as a step in the
+    retirement pipeline (``retire_one_learner.py``), unlike
+    ``RetireCertificatesS3View`` which processes all pending users in one batch.
+
+    Request body (JSON):
+        username (str): the retired username to process (e.g. ``retired__user_...``).
+
+    Auth: requires a JWT/OAuth token for a user with the
+    ``accounts.can_retire_user`` permission.
+
+    Responses:
+        200  All certificates for the user processed successfully.
+             Body: {"username": <str>, "processed": <int>, "failed": []}
+        207  Partial success — some certificates failed.
+             Body: {"username": <str>, "processed": <int>, "failed": [<cert_id>, ...]}
+        400  Missing or empty ``username`` in request body.
+        500  Unexpected error before any processing began.
+    """
+
+    permission_classes = (permissions.IsAuthenticated, CanRetireUser)
+    parser_classes = (JSONParser,)
+
+    def post(self, request):
+        """
+        Delete S3 certificate files for a single retired learner and mark the
+        corresponding GeneratedCertificate records as deleted in the database.
+        """
+        username = request.data.get('username', '').strip()
+        if not username:
+            return Response(
+                {'error': 'username is required in the request body.'},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        s3 = S3Client()
+
+        try:
+            certs = list(_fetch_certs_to_delete_for_user(username))
+        except Exception as exc:  # pylint: disable=broad-except
+            log.exception('retire_certs_s3_for_user: failed to query certificates for user %s: %s', username, exc)
+            return Response(
+                {'error': 'Failed to query certificates from database.'},
+                status=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            )
+
+        log.info('retire_certs_s3_for_user: processing %d certificate(s) for user %s', len(certs), username)
+
+        processed = 0
+        failed_ids = []
+
+        for cert in certs:
+            if _retire_single_cert(s3, cert, 'retire_certs_s3_for_user'):
+                processed += 1
+            else:
+                failed_ids.append(cert.id)
+
+        response_data = {'username': username, 'processed': processed, 'failed': failed_ids}
+
+        if failed_ids:
+            log.warning(
+                'retire_certs_s3_for_user: completed %d certificate(s) for user %s with %d failure(s): cert_ids=%s',
+                processed + len(failed_ids), username, len(failed_ids), failed_ids,
+            )
+            return Response(response_data, status=status.HTTP_207_MULTI_STATUS)
+
+        log.info('retire_certs_s3_for_user: completed %d certificate(s) for user %s successfully', processed, username)
+        return Response(response_data, status=status.HTTP_200_OK)
 
 
 class RetireCertificatesS3View(APIView):
@@ -168,51 +296,17 @@ class RetireCertificatesS3View(APIView):
         failed_ids = []
 
         for cert in certs:
-            try:
-                bucket, verify_prefix, download_key = _s3_keys_from_cert(cert)
-            except ValueError as exc:
-                log.error(
-                    'retire_certs_s3: skipping cert %s (user %s) — bad download_url: %s',
-                    cert.id, cert.user_id, exc,
-                )
-                failed_ids.append(cert.id)
-                continue
-
             if dry_run:
                 log.info(
-                    '[dry_run] Would delete s3://%s/%s*, s3://%s/%s  |  cert_id=%s user_id=%s',
-                    bucket, verify_prefix, bucket, download_key, cert.id, cert.user_id,
-                )
-                processed += 1
-                continue
-
-            try:
-                # Delete S3 objects first. Only update the DB on success.
-                s3.delete_objects_by_prefix(bucket, verify_prefix)
-                s3.delete_object(bucket, download_key)
-
-                cert.status = CertificateStatuses.deleted
-                cert.download_url = ''
-                cert.download_uuid = ''
-                cert.save(update_fields=['status', 'download_url', 'download_uuid'])
-
-                log.info(
-                    'retire_certs_s3: cert %s (user %s) deleted from S3 and marked deleted in DB',
+                    '[dry_run] Would delete s3 objects for cert_id=%s user_id=%s',
                     cert.id, cert.user_id,
                 )
                 processed += 1
+                continue
 
-            except ClientError as exc:
-                log.error(
-                    'retire_certs_s3: S3 error for cert %s (user %s): %s',
-                    cert.id, cert.user_id, exc,
-                )
-                failed_ids.append(cert.id)
-            except Exception as exc:  # pylint: disable=broad-except
-                log.exception(
-                    'retire_certs_s3: unexpected error for cert %s (user %s): %s',
-                    cert.id, cert.user_id, exc,
-                )
+            if _retire_single_cert(s3, cert, 'retire_certs_s3'):
+                processed += 1
+            else:
                 failed_ids.append(cert.id)
 
         response_data = {'processed': processed, 'failed': failed_ids}

--- a/edx_arch_experiments/certificates/views.py
+++ b/edx_arch_experiments/certificates/views.py
@@ -28,6 +28,7 @@ log = logging.getLogger(__name__)
 
 MAX_S3_ATTEMPTS = 5
 _EXPECTED_S3_HOST = 's3.amazonaws.com'
+_RETIRED_USERNAME_PREFIX = 'retired__user_'
 
 
 _S3_DELETE_BATCH_SIZE = 1000
@@ -78,6 +79,7 @@ def _fetch_certs_to_delete_for_user(username):
     """
     return GeneratedCertificate.objects.filter(
         user__username=username,
+        user__username__startswith=_RETIRED_USERNAME_PREFIX,
         download_url__icontains='https://',
         status=CertificateStatuses.downloadable,
     ).select_related('user').order_by('course_id')
@@ -205,6 +207,11 @@ class RetireCertificatesS3ForUserView(APIView):
                 {'error': 'username is required in the request body.'},
                 status=status.HTTP_400_BAD_REQUEST,
             )
+        if not username.startswith(_RETIRED_USERNAME_PREFIX):
+            return Response(
+                {'error': f'username must start with {_RETIRED_USERNAME_PREFIX!r}.'},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
 
         s3 = S3Client()
 
@@ -297,11 +304,16 @@ class RetireCertificatesS3View(APIView):
 
         for cert in certs:
             if dry_run:
-                log.info(
-                    '[dry_run] Would delete s3 objects for cert_id=%s user_id=%s',
-                    cert.id, cert.user_id,
-                )
-                processed += 1
+                try:
+                    bucket, verify_prefix, download_key = _s3_keys_from_cert(cert)
+                    log.info(
+                        '[dry_run] Would delete s3://%s/%s* and s3://%s/%s for cert_id=%s user_id=%s',
+                        bucket, verify_prefix, bucket, download_key, cert.id, cert.user_id,
+                    )
+                    processed += 1
+                except ValueError as exc:
+                    log.error('[dry_run] cert_id=%s user_id=%s would fail: %s', cert.id, cert.user_id, exc)
+                    failed_ids.append(cert.id)
                 continue
 
             if _retire_single_cert(s3, cert, 'retire_certs_s3'):


### PR DESCRIPTION
### Description

Adds a per-user certificate retirement endpoint to support the retirement pipeline, and refactors the existing batch endpoint to reuse shared deletion logic while adding standalone unit tests for the certificate retirement views.

**Changes:**

- Added POST /api/certificates/v1/retire_certs_s3_for_user to retire certificates for a single (retired) username.
- Introduced _retire_single_cert helper and refactored the batch retirement view to use it.
- Added standalone unit tests for S3 key derivation, per-cert retirement, and both endpoints.


**Merge checklist:**
Check off if complete *or* not applicable:
- [x] Version bumped
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [x] Fixup commits are squashed away
- [x] Unit tests added/updated
- [x] Manual testing instructions provided
- [x] Noted any: Concerns, dependencies, migration issues, deadlines, tickets

**Related Private repo PR :**

- https://github.com/edx/edx-internal/pull/14325
- https://github.com/edx/tubular/pull/68

**Private Jira ticket:**

- https://2u-internal.atlassian.net/browse/BOMS-488
