### PR TITLE
feat: Add batch size parameter to retire_certs_s3 for incremental processing

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,12 @@ Change Log
 Unreleased
 **********
 
+[7.5.0] - 2026-05-14
+********************
+Added
+=====
+* Added optional ``?batch_size=N`` query parameter to ``retire_certs_s3`` to limit certificates processed per call.
+
 [7.4.0] - 2026-04-28
 ********************
 Added

--- a/edx_arch_experiments/__init__.py
+++ b/edx_arch_experiments/__init__.py
@@ -2,4 +2,4 @@
 A plugin to include applications under development by the architecture team at 2U.
 """
 
-__version__ = '7.4.0'
+__version__ = '7.5.0'

--- a/edx_arch_experiments/certificates/views.py
+++ b/edx_arch_experiments/certificates/views.py
@@ -129,6 +129,9 @@ class RetireCertificatesS3View(APIView):
     Query parameters:
         dry_run (bool, default false): when true, logs actions but makes no
             changes to S3 or the database.
+        batch_size (int, default 0): when non-zero, limits the number of
+            certificates processed in a single call. Use with a scheduled job
+            to drain the queue incrementally.
 
     Auth: requires a JWT/OAuth token for a user with the
     ``accounts.can_retire_user`` permission (same permission used by all other
@@ -151,10 +154,17 @@ class RetireCertificatesS3View(APIView):
         corresponding GeneratedCertificate records as deleted in the database.
         """
         dry_run = request.query_params.get('dry_run', 'false').lower() == 'true'
+        try:
+            batch_size = int(request.query_params.get('batch_size', 0))
+        except (ValueError, TypeError):
+            batch_size = 0
         s3 = S3Client()
 
         try:
-            certs = _fetch_certs_to_delete().iterator(chunk_size=100)
+            certs = _fetch_certs_to_delete()
+            if batch_size > 0:
+                certs = certs[:batch_size]
+            certs = certs.iterator(chunk_size=100)
         except Exception as exc:  # pylint: disable=broad-except
             log.exception('retire_certs_s3: failed to query certificates: %s', exc)
             return Response(
@@ -162,7 +172,7 @@ class RetireCertificatesS3View(APIView):
                 status=status.HTTP_500_INTERNAL_SERVER_ERROR,
             )
 
-        log.info('retire_certs_s3: starting certificate retirement (dry_run=%s)', dry_run)
+        log.info('retire_certs_s3: starting certificate retirement (dry_run=%s, batch_size=%s)', dry_run, batch_size or 'unlimited')
 
         processed = 0
         failed_ids = []

--- a/edx_arch_experiments/certificates/views.py
+++ b/edx_arch_experiments/certificates/views.py
@@ -158,6 +158,11 @@ class RetireCertificatesS3View(APIView):
             batch_size = int(request.query_params.get('batch_size', 0))
         except (ValueError, TypeError):
             batch_size = 0
+        if batch_size < 0:
+            return Response(
+                {'error': 'batch_size must be a non-negative integer (0 = no limit).'},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
         s3 = S3Client()
 
         try:
@@ -172,7 +177,10 @@ class RetireCertificatesS3View(APIView):
                 status=status.HTTP_500_INTERNAL_SERVER_ERROR,
             )
 
-        log.info('retire_certs_s3: starting certificate retirement (dry_run=%s, batch_size=%s)', dry_run, batch_size or 'unlimited')
+        log.info(
+            'retire_certs_s3: starting certificate retirement (dry_run=%s, batch_size=%s)',
+            dry_run, batch_size or 'unlimited',
+        )
 
         processed = 0
         failed_ids = []


### PR DESCRIPTION
### Overview:

Adds an optional batch_size query parameter to the certificate S3 retirement endpoint so scheduled jobs can process certificates incrementally instead of draining the full queue in one call.

Changes:

- Parses batch_size from RetireCertificatesS3View query params and applies it as a queryset limit.
- Logs the effective batch size when retirement starts.
- Bumps package version to 7.5.0 and adds a changelog entry

**Private JIRA ticket:**

- https://2u-internal.atlassian.net/browse/BOMS-488

**Related PR(private):**

- https://github.com/edx/configuration/pull/341
- https://github.com/edx/jenkins-job-dsl/pull/1841
- https://github.com/edx/edx-internal/pull/14343


**Merge checklist:**
Check off if complete *or* not applicable:
- [x] Version bumped
- [x] Changelog record added
- [x] Fixup commits are squashed away
