### PR TITLE
fix: add trailing slash to retire_certs_s3_for_user URL pattern

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,12 @@ Change Log
 Unreleased
 **********
 
+[7.7.0] - 2026-05-26
+********************
+Fixed
+=====
+* Added trailing slash to ``retire_certs_s3_for_user/`` URL pattern.
+
 [7.6.0] - 2026-05-11
 ********************
 Added
@@ -299,6 +305,20 @@ Fixed
 ********************
 
 * Update consumer to use bridge and signals
+
+[0.1.1] - 2022-03-16
+********************
+
+* Fix GitHub actions
+
+[0.1.0] - 2022-02-22
+********************
+
+Added
+=====
+
+* First release on PyPI.
+use bridge and signals
 
 [0.1.1] - 2022-03-16
 ********************

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -318,17 +318,3 @@ Added
 =====
 
 * First release on PyPI.
-use bridge and signals
-
-[0.1.1] - 2022-03-16
-********************
-
-* Fix GitHub actions
-
-[0.1.0] - 2022-02-22
-********************
-
-Added
-=====
-
-* First release on PyPI.

--- a/edx_arch_experiments/__init__.py
+++ b/edx_arch_experiments/__init__.py
@@ -2,4 +2,4 @@
 A plugin to include applications under development by the architecture team at 2U.
 """
 
-__version__ = '7.6.0'
+__version__ = '7.7.0'

--- a/edx_arch_experiments/certificates/tests/test_views.py
+++ b/edx_arch_experiments/certificates/tests/test_views.py
@@ -234,7 +234,7 @@ class TestRetireCertificatesS3ForUserView(_BaseViewTestCase):
     def _post(self, data=None):
         """POST to retire_certs_s3_for_user and return the DRF Response."""
         request = self.factory.post(
-            '/api/certificates/v1/retire_certs_s3_for_user',
+            '/api/certificates/v1/retire_certs_s3_for_user/',
             data=json.dumps(data or {}),
             content_type='application/json',
         )

--- a/edx_arch_experiments/certificates/urls.py
+++ b/edx_arch_experiments/certificates/urls.py
@@ -8,5 +8,5 @@ from edx_arch_experiments.certificates.views import RetireCertificatesS3ForUserV
 
 urlpatterns = [
     path('retire_certs_s3', RetireCertificatesS3View.as_view(), name='retire_certs_s3'),
-    path('retire_certs_s3_for_user', RetireCertificatesS3ForUserView.as_view(), name='retire_certs_s3_for_user'),
+    path('retire_certs_s3_for_user/', RetireCertificatesS3ForUserView.as_view(), name='retire_certs_s3_for_user'),
 ]


### PR DESCRIPTION
**Description:**

The retire_certs_s3_for_user URL was missing a trailing slash. Tubular's get_api_url() always appends a trailing slash, so the POST request hit .../retire_certs_s3_for_user/ which Django redirected (301) to a GET, returning 404 since no GET handler exists.

**Changes**
added trailing slash to the URL pattern in certificates/urls.py.

**Merge checklist:**
Check off if complete *or* not applicable:
- [x] Version bumped
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [x] Fixup commits are squashed away
- [x] Unit tests added/updated
- [x] Manual testing instructions provided
- [x] Noted any: Concerns, dependencies, migration issues, deadlines, tickets

JIRA ticket:

- https://2u-internal.atlassian.net/browse/BOMS-558
